### PR TITLE
Support sending images slack -> matrix

### DIFF
--- a/app.js
+++ b/app.js
@@ -92,7 +92,7 @@ new Cli({
                 },
             }
         });
-        var slackHookHandler = new SlackHookHandler(config, rooms, bridge);
+        var slackHookHandler = new SlackHookHandler(requestLib, config, rooms, bridge);
         startServer(config, slackHookHandler, function() {
             console.log("Matrix-side listening on port %s", port);
             bridge.run(port, config);

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -2,10 +2,14 @@ slack_hook_port: 9898
 bot_username: "slackbot"
 username_prefix: "slack_"
 
+# Optional
+slack_master_token: "abc-123-def"
+
 homeserver:
   url: http://localhost:8008
   server_name: my.server
 
+# Optional
 tls:
   key_file: /path/to/tls.key
   crt_file: /path/to/tls.crt

--- a/config/slack-config-schema.yaml
+++ b/config/slack-config-schema.yaml
@@ -37,3 +37,7 @@ properties:
     type: string
   username_prefix:
     type: string
+  slack_master_token:
+    # Required for some functionality, like sending images from Slack to Matrix.
+    # Bridge gracefully degrades if no slack_master_token is specified.
+    type: string

--- a/lib/rooms.js
+++ b/lib/rooms.js
@@ -34,6 +34,14 @@ Rooms.prototype.webhookForMatrixRoomID = function(matrix_room_id) {
     return room.webhook_url;
 };
 
+Rooms.prototype.slackChannelForMatrixRoomID = function(matrix_room_id) {
+    var room = this.matrix_rooms[matrix_room_id];
+    if (!room) {
+        return null;
+    }
+    return room.slack_channel_id;
+};
+
 Rooms.prototype.tokenForSlackChannel = function(slack_channel_id) {
     var channel = this.slack_channels[slack_channel_id];
     if (!channel) {

--- a/lib/slack-hook-handler.js
+++ b/lib/slack-hook-handler.js
@@ -97,7 +97,12 @@ SlackHookHandler.prototype.lookupAndSendNonTextMessage =
                 return;
             }
             if (resp.messages.length != 1) {
-                // Just laziness
+                // Just laziness.
+                // If we get unlucky and two messages were sent at exactly the
+                // same microsecond, we could parse them all, filter by user,
+                // filter by whether they have attachments, and such, and pick
+                // the right message. But this is unlikely, and I'm lazy, so
+                // we'll just drop the message...
                 console.log("Really unlucky, got multiple messages at same" +
                     " microsecond, dropping:" + body);
                 return;

--- a/lib/slack-hook-handler.js
+++ b/lib/slack-hook-handler.js
@@ -31,16 +31,21 @@ SlackHookHandler.prototype.getIntent = function(slackUser) {
  * Attempts to make the message as native-matrix feeling as it can.
  *
  * @param {Object} params HTTP body of the webhook request, as a JSON-parsed dictionary.
+ * @param {string} params.channel_id Slack channel ID receiving the message.
+ * @param {string} params.channel_name Slack channel name receiving the message.
+ * @param {string} params.user_id Slack user ID of user sending the message.
+ * @param {string} params.user_name Slack user name of the user sending the message.
+ * @param {?string} params.text Text contents of the message, if a text message.
+ * @param {string} timestamp Timestamp when message was received, in seconds
+ *     formatted as a float.
  */
 SlackHookHandler.prototype.handle = function(params) {
     if (params.user_id === "USLACKBOT") {
         return;
     }
     if (!this.rooms.knowsSlackChannel(params.channel_id)) {
-        console.log(
-            "Ignoring message for slack channel " +
-            "with unknown matrix ID: " + params.channel_id +
-            " (" + params.channel_name + ")"
+        console.log("Ignoring message for slack channel with unknown matrix ID: %s (%s)",
+            params.channel_id, params.channel_name
         );
         return;
     }
@@ -50,6 +55,8 @@ SlackHookHandler.prototype.handle = function(params) {
         intent.sendText(roomID, substitutions.slackToMatrix(params.text));
         return;
     }
+    // Attachments are never sent to a webhook, so we need to actually request
+    // the message history of the room to get information about attachments.
     this.lookupAndSendNonTextMessage(params.channel_id, params.timestamp, intent, roomID);
     return;
 };
@@ -68,6 +75,8 @@ SlackHookHandler.prototype.lookupAndSendNonTextMessage =
     if (!this.config.slack_master_token) {
         return;
     }
+    // Look up all messages at the exact timestamp we received.
+    // This has microsecond granularity, so should return the message we want.
     var params = {
         channel: channelID,
         latest: timestamp,
@@ -88,8 +97,10 @@ SlackHookHandler.prototype.lookupAndSendNonTextMessage =
                 return;
             }
             if (resp.messages.length != 1) {
+                // Just laziness
                 console.log("Really unlucky, got multiple messages at same" +
                     " microsecond, dropping:" + body);
+                return;
             }
             var message = resp.messages[0];
             if (!message.file) {

--- a/lib/slack-hook-handler.js
+++ b/lib/slack-hook-handler.js
@@ -4,13 +4,15 @@ var substitutions = require("./substitutions");
 
 /**
  * @constructor
+ * @param {request} requestLib request library, for sending HTTP requests.
  * @param {Object} config the configuration of the bridge.
  *     See ../config/slack-config-schema.yaml for the schema to which this must conform.
  * @param {Rooms} rooms mapping of all known slack channels to matrix rooms.
  * @param {Bridge} bridge the matrix-appservice-bridge bridge through which to
  *     communicate with matrix.
  */
-function SlackHookHandler(config, rooms, bridge) {
+function SlackHookHandler(requestLib, config, rooms, bridge) {
+    this.requestLib = requestLib;
     this.config = config;
     this.rooms = rooms;
     this.bridge = bridge;
@@ -31,22 +33,120 @@ SlackHookHandler.prototype.getIntent = function(slackUser) {
  * @param {Object} params HTTP body of the webhook request, as a JSON-parsed dictionary.
  */
 SlackHookHandler.prototype.handle = function(params) {
-    if (params.user_id !== "USLACKBOT" && params.text) {
-        var intent = this.getIntent(params.user_name);
-        if (this.rooms.knowsSlackChannel(params.channel_id)) {
-            var roomID = this.rooms.matrixRoomID(params.channel_id);
-            if (roomID) {
-                intent.sendText(roomID, substitutions.slackToMatrix(params.text));
+    if (params.user_id === "USLACKBOT") {
+        return;
+    }
+    if (!this.rooms.knowsSlackChannel(params.channel_id)) {
+        console.log(
+            "Ignoring message for slack channel " +
+            "with unknown matrix ID: " + params.channel_id +
+            " (" + params.channel_name + ")"
+        );
+        return;
+    }
+    var intent = this.getIntent(params.user_name);
+    var roomID = this.rooms.matrixRoomID(params.channel_id);
+    if (params.text) {
+        intent.sendText(roomID, substitutions.slackToMatrix(params.text));
+        return;
+    }
+    this.lookupAndSendNonTextMessage(params.channel_id, params.timestamp, intent, roomID);
+    return;
+};
+
+/**
+ * Attempts to handle a non-text message received from a slack webhook request.
+ *
+ * @param {string} channelID Slack channel ID.
+ * @param {string} timestamp Timestamp when message was received, in seconds
+ *     formatted as a float.
+ * @param {Intent} intent Intent for sending messages as the relevant user.
+ * @param {string} roomID Matrix room ID associated with channelID.
+ */
+SlackHookHandler.prototype.lookupAndSendNonTextMessage =
+        function(channelID, timestamp, intent, roomID) {
+    if (!this.config.slack_master_token) {
+        return;
+    }
+    var params = {
+        channel: channelID,
+        latest: timestamp,
+        oldest: timestamp,
+        inclusive: "1",
+        token: this.config.slack_master_token,
+    };
+    var self = this;
+    this.requestLib.post("https://slack.com/api/channels.history", {form: params},
+            function(err, _, body) {
+        if (err) {
+            console.log("Error looking up history: %s", err);
+        }
+        else {
+            var resp = JSON.parse(body);
+            if (!resp.ok || !resp.messages) {
+                console.log("Could not find history: " + body);
+                return;
             }
-            else {
-                console.log(
-                    "Ignoring message for slack channel " +
-                    "with unknown matrix ID: " + params.channel_id +
-                    " (" + params.channel_name + ")"
-                );
+            if (resp.messages.length != 1) {
+                console.log("Really unlucky, got multiple messages at same" +
+                    " microsecond, dropping:" + body);
             }
+            var message = resp.messages[0];
+            if (!message.file) {
+                console.log("Ignoring non-text non-image message: " + body);
+                return;
+            }
+            if (message.file.mimetype && message.file.mimetype.indexOf("image/") === 0) {
+                var matrixMessage = self.slackImageToMatrixImage(message.file);
+                intent.sendMessage(roomID, matrixMessage);
+                if (message.file.initial_comment) {
+                    var text = substitutions.slackToMatrix(
+                        message.file.initial_comment.comment
+                    );
+                    intent.sendText(roomID, text);
+                }
+                return;
+            }
+            console.log("Ignoring non-image attachment: " + body);
+        }
+    });
+};
+
+/**
+ * Converts a slack image attachment to a matrix image event.
+ *
+ * @param {Object} file The slack image attachment file object.
+ * @return {Object} Matrix event content.
+ */
+SlackHookHandler.prototype.slackImageToMatrixImage = function(file) {
+    var message = {
+        msgtype: "m.image",
+        url: file.url,
+        body: file.title,
+        info: {
+            mimetype: file.mimetype
+        }
+    };
+    if (file.original_w) {
+        message.info.w = file.original_w;
+    }
+    if (file.original_h) {
+        message.info.h = file.original_h;
+    }
+    if (file.size) {
+        message.info.size = file.size;
+    }
+    if (file.thumb_360) {
+        message.thumbnail_url = file.thumb_360;
+        message.thumbnail_info = {};
+        if (file.thumb_360_w) {
+            message.thumbnail_info.w = file.thumb_360_w;
+        }
+        if (file.thumb_360_h) {
+            message.thumbnail_info.h = file.thumb_360_h;
         }
     }
+    return message;
 };
 
 SlackHookHandler.prototype.checkAuth = function(params) {

--- a/lib/slack-hook-handler.js
+++ b/lib/slack-hook-handler.js
@@ -92,7 +92,7 @@ SlackHookHandler.prototype.lookupAndSendNonTextMessage =
         }
         else {
             var resp = JSON.parse(body);
-            if (!resp.ok || !resp.messages) {
+            if (!resp.ok || !resp.messages || resp.messages.length === 0) {
                 console.log("Could not find history: " + body);
                 return;
             }
@@ -132,7 +132,19 @@ SlackHookHandler.prototype.lookupAndSendNonTextMessage =
  * Converts a slack image attachment to a matrix image event.
  *
  * @param {Object} file The slack image attachment file object.
- * @return {Object} Matrix event content.
+ * @param {string} file.url URL of the file.
+ * @param {string} file.title alt-text for the file.
+ * @param {string} file.mimetype mime-type of the file.
+ * @param {?integer} file.size size of the file in bytes.
+ * @param {?integer} file.original_w width of the file if an image, in pixels.
+ * @param {?integer} file.original_h height of the file if an image, in pixels.
+ * @param {?string} file.thumb_360 URL of a 360 pixel wide thumbnail of the
+ *     file, if an image.
+ * @param {?integer} file.thumb_360_w width of the thumbnail of the 360 pixel
+ *     wide thumbnail of the file, if an image.
+ * @param {?integer} file.thumb_360_h height of the thumbnail of the 36 pixel
+ *     wide thumbnail of the file, if an image.
+ * @return {Object} Matrix event content, as per https://matrix.org/docs/spec/#m-image
  */
 SlackHookHandler.prototype.slackImageToMatrixImage = function(file) {
     var message = {

--- a/tests/slack-hook-handler.spec.js
+++ b/tests/slack-hook-handler.spec.js
@@ -11,14 +11,24 @@ function makeRequest(user, text) {
 }
 
 describe("SlackHookHandler.handle", function() {
+    var requestLib;
     var handler;
     var intent;
+    var config;
+    var timestamp = "1443017615.000193";
+
+    function assertNoMessagesSent() {
+        expect(intent.sendMessage).not.toHaveBeenCalled();
+        expect(intent.sendText).not.toHaveBeenCalled();
+    }
 
     beforeEach(function() {
-        var config = {
+        requestLib = {};
+        config = {
             homeserver: {
                 server_name: "foo.bar"
-            }
+            },
+            slack_master_token: "leavinganote"
         };
         var rooms = {
             knowsSlackChannel: function(channel_name) {
@@ -28,19 +38,19 @@ describe("SlackHookHandler.handle", function() {
                 return channel_name == "slackchan" ? "!room:host" : null;
             }
         };
-        intent = {};
+        intent = createSpyObj("intent", ["sendMessage", "sendText"]);
         var bridge = {
             getIntent: function() {
                 return intent;
             }
         };
-        handler = new SlackHookHandler(config, rooms, bridge);
+        handler = new SlackHookHandler(requestLib, config, rooms, bridge);
     });
 
     describe("handle text messages", function() {
         it("ignores slackbot", function() {
             handler.handle(makeRequest("USLACKBOT"));
-            // If any methods had been called on intent, we would have thrown.
+            assertNoMessagesSent();
         });
         it("sends text messages", function() {
             intent = createSpyObj("intent", ["sendText"]);
@@ -50,10 +60,169 @@ describe("SlackHookHandler.handle", function() {
 
         });
         it("unescapes special characters", function() {
-            intent = createSpyObj("intent", ["sendText"]);
             handler.handle(makeRequest("GOB", "&lt;special &amp; characters&gt;"));
             expect(intent.sendText).toHaveBeenCalledWith(
                 "!room:host", "<special & characters>");
+        });
+    });
+
+    function mockChannelHistory(reply) {
+        requestLib.post = function(url, params, cb) {
+            expect(url).toEqual("https://slack.com/api/channels.history");
+            expect(params).toEqual({form: {
+                channel: "slackchan",
+                latest: timestamp,
+                oldest: timestamp,
+                inclusive: "1",
+                token: "leavinganote",
+            }});
+            cb(null, undefined, JSON.stringify(reply));
+        };
+    }
+
+    function receiveImage() {
+        handler.handle({
+                "channel_id": "slackchan",
+                "channel_name": "tantamount_studios",
+                "timestamp": "1443017615.000193",
+                "user_id": "MF",
+                "user_name": "maeby"
+        });
+    }
+
+    describe("handles image message", function() {
+        it("ignores images if no master token set", function() {
+            delete config.slack_master_token;
+            requestLib = createSpyObj("requestLib", ["post"]);
+            receiveImage();
+            expect(requestLib.post).not.toHaveBeenCalled();
+            assertNoMessagesSent();
+        });
+        it("sends image", function() {
+            mockChannelHistory({
+                ok: true,
+                messages: [{
+                    type: "message",
+                    subtype: "file_share",
+                    file: {
+                        mimetype: "image/jpeg",
+                        size: 123,
+                        url: "http://almost.cousins/kissing.jpg",
+                        title: "GM&M",
+                        original_w: 1024,
+                        original_h: 768
+                    }
+                }]
+            });
+            receiveImage();
+            expect(intent.sendMessage).toHaveBeenCalledWith(
+                "!room:host", {
+                    msgtype: "m.image",
+                    url: "http://almost.cousins/kissing.jpg",
+                    body: "GM&M",
+                    info: {
+                        mimetype: "image/jpeg",
+                        size: 123,
+                        w: 1024,
+                        h: 768
+                    }
+                }
+            );
+        });
+        it("sends image with thumbnail", function() {
+            mockChannelHistory({
+                ok: true,
+                messages: [{
+                    type: "message",
+                    subtype: "file_share",
+                    file: {
+                        mimetype: "image/jpeg",
+                        size: 123,
+                        url: "http://almost.cousins/kissing.jpg",
+                        title: "GM&M",
+                        original_w: 1024,
+                        original_h: 768,
+                        thumb_360: "http://almost.cousins/kissing_360.jpg",
+                        thumb_360_w: 360,
+                        thumb_360_h: 240
+                    }
+                }]
+            });
+            receiveImage();
+            expect(intent.sendMessage).toHaveBeenCalledWith(
+                "!room:host", {
+                    msgtype: "m.image",
+                    url: "http://almost.cousins/kissing.jpg",
+                    thumbnail_url: "http://almost.cousins/kissing_360.jpg",
+                    body: "GM&M",
+                    info: {
+                        mimetype: "image/jpeg",
+                        size: 123,
+                        w: 1024,
+                        h: 768
+                    },
+                    thumbnail_info: {
+                        w: 360,
+                        h: 240
+                    }
+                }
+            );
+        });
+        it("sends image with comment", function() {
+            mockChannelHistory({
+                ok: true,
+                messages: [{
+                    type: "message",
+                    subtype: "file_share",
+                    file: {
+                        mimetype: "image/jpeg",
+                        size: 123,
+                        url: "http://almost.cousins/kissing.jpg",
+                        title: "GM&M",
+                        original_w: 1024,
+                        original_h: 768,
+                        initial_comment: {
+                            comment: "&lt;It's only 63 minutes long&gt;"
+                        }
+                    }
+                }]
+            });
+            receiveImage();
+            expect(intent.sendMessage).toHaveBeenCalledWith(
+                "!room:host", {
+                    msgtype: "m.image",
+                    url: "http://almost.cousins/kissing.jpg",
+                    body: "GM&M",
+                    info: {
+                        mimetype: "image/jpeg",
+                        size: 123,
+                        w: 1024,
+                        h: 768
+                    }
+                }
+            );
+            expect(intent.sendText).toHaveBeenCalledWith(
+                "!room:host",
+                "<It's only 63 minutes long>"
+            );
+        });
+        it("ignores non-images", function() {
+            mockChannelHistory({
+                ok: true,
+                messages: [{
+                    type: "message",
+                    subtype: "file_share",
+                    file: {
+                        mimetype: "application/monkeys",
+                        size: 123,
+                        url: "http://almost.cousins/kissing.jpg",
+                        title: "GM&M",
+                        original_w: 1024,
+                        original_h: 768
+                    }
+                }]
+            });
+            assertNoMessagesSent();
         });
     });
 
@@ -61,6 +230,7 @@ describe("SlackHookHandler.handle", function() {
 
 describe("SlackHookHandler", function() {
     it("gets intent", function() {
+        var requestLib = undefined;
         var config = {
             username_prefix: "prefix_",
             homeserver: {
@@ -69,7 +239,7 @@ describe("SlackHookHandler", function() {
         };
         var rooms = undefined;
         var bridge = createSpyObj("bridge", ["getIntent"]);
-        var handler = new SlackHookHandler(config, rooms, bridge)
+        var handler = new SlackHookHandler(requestLib, config, rooms, bridge)
         handler.getIntent("foo");
         expect(bridge.getIntent).toHaveBeenCalledWith("@prefix_foo:my.homeserver");
     });


### PR DESCRIPTION
Only supported if a slack_master_token is specified, which is a token
with permission to view history of each room being bridged.