### PR TITLE
Provisioning API

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "ecmaFeatures": {
+    "templateStrings": true
+  },
   "env": {
     "node": true,
     "jasmine": true

--- a/app.js
+++ b/app.js
@@ -8,8 +8,9 @@ var requestLib = require("request");
 var Rooms = require("./lib/rooms");
 var SlackHookHandler = require("./lib/slack-hook-handler");
 var MatrixHandler = require("./lib/matrix-handler");
+var Provisioner = require("./lib/provisioning.js").Provisioner;
 var bridgeLib = require("matrix-appservice-bridge");
-var bridge;
+var bridge, provisioner;
 
 function startServer(config, hookHandler, callback) {
     var createServer;
@@ -96,6 +97,9 @@ var cli = new Cli({
         startServer(config, slackHookHandler, function() {
             console.log("Matrix-side listening on port %s", port);
             bridge.run(port, config);
+
+            console.log("Setting up provisioning...");
+            provisioner = new Provisioner(bridge, rooms, true);
         });
     }
 });

--- a/lib/provisioning.js
+++ b/lib/provisioning.js
@@ -1,0 +1,180 @@
+/*eslint no-invalid-this: 0*/ // eslint doesn't understand Promise.coroutine wrapping
+"use strict";
+
+function Provisioner (bridge, rooms, enabled) {
+    this._bridge = bridge;
+    this._rooms = rooms;
+
+    if (enabled) {
+        console.log("Starting provisioning...");
+    }
+    else {
+        console.log("Provisioning disabled.");
+    }
+
+    var appService = this._bridge.appService;
+    var self = this;
+
+    if (enabled && !(appService.app.use && appService.app.get && appService.app.post)) {
+        throw new Error('Could not start provisioning API');
+    }
+
+    // Disable all provision endpoints by not calling 'next', returning an error
+    if (!enabled) {
+        appService.app.use(function(req, res, next) {
+            if (self.isProvisionRequest(req)) {
+                res.status(500);
+                res.json({error : 'Provisioning is not enabled.'});
+            }
+            else {
+                next();
+            }
+        });
+    }
+
+    // Deal with CORS (temporarily for s-web)
+    appService.app.use(function(req, res, next) {
+        if (self.isProvisionRequest(req)) {
+                res.header("Access-Control-Allow-Origin", "*");
+                res.header("Access-Control-Allow-Headers",
+                    "Origin, X-Requested-With, Content-Type, Accept");
+        }
+        next();
+    });
+
+    appService.app.post("/_matrix/provision/link", function(req, res) {
+        try {
+            //link
+            self.link(req.body);
+
+            res.json({});
+        }
+        catch (err) {
+            res.status(500).json({error: err.message});
+            throw err;
+        }
+    });
+
+    appService.app.post("/_matrix/provision/unlink", function(req, res) {
+        try {
+            //unlink
+            self.unlink(req.body);
+            res.json({});
+        }
+        catch (err) {
+            res.status(500).json({error: err.message});
+            throw err;
+        }
+    });
+
+    appService.app.get("/_matrix/provision/listlinks/:roomId", function(req, res) {
+        try {
+            //list
+            var list = self.listings(req.params.roomId);
+            res.json(list);
+        }
+        catch (err) {
+            res.status(500).json({error: err.message});
+            throw err;
+        }
+    });
+
+    if (enabled) {
+        console.log("Provisioning started");
+    }
+}
+
+Provisioner.prototype.isProvisionRequest = function(req) {
+    return req.url === '/_matrix/provision/unlink' ||
+            req.url === '/_matrix/provision/link'||
+            req.url.match(/^\/_matrix\/provision\/listlinks/)
+};
+
+var parameterValidation = {
+    slack_channel_id :
+        {regex : /^[A-Z0-9]+$/, example : 'C0234V346'},
+    slack_api_token :
+        {regex : /^.+$/, example : 'dfsdfsdfsdfsdfsdfsdfsdf'},
+    matrix_room_id :
+        {regex : /^!.*:.*$/, example : '!Abcdefg:example.com[:8080]'},
+    webhook_url :
+        {regex : /^.+$/, example : 'http://webhooks.com/captainhook'},
+};
+
+Provisioner.prototype._validate = function(actual, parameterName) {
+    var valid = parameterValidation[parameterName];
+
+    if (!valid) {
+        throw new Error(
+            `Parameter name not recognised (${parameterName}).`
+        );
+    }
+
+    if (!actual) {
+        throw new Error(
+            `${parameterName} not provided (like '${valid.example}').`
+        );
+    }
+
+    if (typeof actual !== 'string') {
+        throw new Error(
+            `${parameterName} should be a string (like '${valid.example}').`
+        );
+    }
+
+    if (!actual.match(valid.regex)) {
+        throw new Error(
+            `Malformed ${parameterName} ('${actual}'),` +
+            ` should look like '${valid.example}'.`
+        );
+    }
+};
+
+// Validate parameters for use in linking/unlinking
+Provisioner.prototype._validateAll = function(parameters, parameterNames) {
+    for (var i = 0; i < parameterNames.length; i++) {
+        this._validate(parameters[parameterNames[i]], parameterNames[i]);
+    }
+};
+
+// Link a slack channel to a matrix room ID
+Provisioner.prototype.link = function(options) {
+    this._validateAll(options, [
+        'slack_channel_id', 'slack_api_token',
+        'matrix_room_id', 'webhook_url'
+    ]);
+
+    var slack_channel_id = options.slack_channel_id;
+    var slack_api_token = options.slack_api_token;
+    var matrix_room_id = options.matrix_room_id;
+    var webhook_url = options.webhook_url;
+
+    this._rooms.addRoom(slack_channel_id, slack_api_token, matrix_room_id, webhook_url);
+};
+
+// Unlink a slack channel from a matrix room ID
+Provisioner.prototype.unlink = function(options) {
+    this._validateAll(options, ['slack_channel_id', 'matrix_room_id']);
+
+    var slack_channel_id = options.slack_channel_id;
+    var matrix_room_id = options.matrix_room_id;
+
+    this._rooms.removeRoom(slack_channel_id, matrix_room_id);
+};
+
+// List all mappings currently provisioned with the given matrix_room_id
+Provisioner.prototype.listings = function(roomId) {
+    this._validate(roomId, 'matrix_room_id');
+
+    var room = this._rooms.matrix_rooms[roomId];
+
+    if (!room) {
+        return [];
+    }
+
+    return [room];
+};
+
+module.exports = {
+    Provisioner : Provisioner
+};

--- a/lib/rooms.js
+++ b/lib/rooms.js
@@ -6,8 +6,31 @@ function Rooms(config) {
     for (var i = 0; i < config.rooms.length; ++i) {
         var room = config.rooms[i];
         this.slack_channels[room["slack_channel_id"]] = room;
-        this.matrix_rooms[room["matrix_room_id"]] = room
+        this.matrix_rooms[room["matrix_room_id"]] = room;
     }
+}
+
+Rooms.prototype.addRoom = function (
+    slack_channel_id, slack_api_token,
+    matrix_room_id, webhook_url) {
+        if (! (slack_channel_id && matrix_room_id)) {
+            throw new Error('Slack channel ID and Matrix room ID required');
+        }
+
+        var room = {
+            slack_channel_id : slack_channel_id,
+            slack_api_token : slack_api_token,
+            matrix_room_id : matrix_room_id,
+            webhook_url : webhook_url
+        };
+
+        this.slack_channels[slack_channel_id] = room;
+        this.matrix_rooms[matrix_room_id] = room;
+};
+
+Rooms.prototype.removeRoom = function (slack_channel_id, matrix_room_id) {
+    delete this.slack_channels[slack_channel_id];
+    delete this.matrix_rooms[matrix_room_id];
 }
 
 Rooms.prototype.knowsSlackChannel = function(slack_channel_id) {


### PR DESCRIPTION
Implemented a few endpoints, much in the same way the IRC bridge does (https://github.com/matrix-org/matrix-appservice-irc/pull/128) 

```
POST /_matrix/provisioning/link
POST /_matrix/provisioning/unlink
GET /_matrix/provisioning/listlinks/!matrix:roomid
```

/link
----
Create a mapping between a matrix room and a slack channel.
Accepts the following:
```JSON
{
 "slack_channel_id":"C200XPMGV",
 "matrix_room_id":"!matrix:roomid",
 "slack_api_token":"someAPItokenfromslack",
 "webhook_url":"someurlfromslack"
}
```


/unlink
----
Remove a mapping between a matrix room and a slack channel.
Accepts the following:
```JSON
{
 "slack_channel_id":"C200XPMGV",
 "matrix_room_id":"!matrix:roomid"
}
```

/listlinks/:roomId
----
List mappings for a certain matrix room ID.
Accepts something like roomId = "!matrix:roomid"