### PR TITLE
Replace Riot pills mention to slack mention

### DIFF
--- a/lib/Main.js
+++ b/lib/Main.js
@@ -188,6 +188,10 @@ Main.prototype.getBotIntent = function() {
     return this._bridge.getIntent();
 };
 
+Main.prototype.getUsernamePrefix = function() {
+    return this._config.username_prefix;
+};
+
 // Returns a Promise of a SlackGhost
 Main.prototype.getGhostForSlackMessage = function(message) {
     // Slack ghost IDs need to be constructed from user IDs, not usernames,

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -115,6 +115,20 @@ var matrixToSlack = function(event, main) {
         if (event.content.msgtype == "m.emote") {
             string = "_" + string + "_";
         }
+
+        // replace riot "pill" behavior to "@" mention for slack users
+        var html_string = event.content.formatted_body;
+        if (undefined != html_string) {
+            var regex = new RegExp('<a href="https://matrix.to/#/@' +
+                                   main.getUsernamePrefix() +
+                                   '[^"]+">([^<]+)</a>', "g");
+
+            var match = regex.exec(html_string);
+            while (match != null) {
+                string = string.replace(match[1], "@" + match[1]);
+                match = regex.exec(html_string);
+            }
+        }
     }
 
     // the link_names flag means that writing @username will act as a mention in slack


### PR DESCRIPTION
Fix #52

Actually if you write `"someone <a href="…">someone</a>`, the first occurrence of "someone" will get converted to "@someone" instead of the 2d, but it does not seem to much annoying to add the complexity to handle it.