### PR TITLE
Url

### DIFF
--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -71,7 +71,7 @@ var slackToMatrix = function(body) {
     // remove <> from links. if you post http://oddvar.org in slack,
     // this becomes <http://oddvar.org> in the event sent to Matrix
     // so we need to strip <> from the link
-    body = body.replace(/<((https?:\/\/)?[^>]+?)>/g, '$1');
+    body = body.replace(/<(https?:\/\/[^>]+?)>/g, '$1');
 
     // attempt to match any text inside colons to emoji, e.g. :smiley:
     // we use replace to run a function on each match, replacing matches in buf

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -65,8 +65,8 @@ var slackToMatrix = function(body) {
     // escape slack-links e.g:
     // "hello @oddvar:<http://oddvar.org|oddvar.org> how are ya"
     // becomes
-    // hello @oddvar:oddvar.org how are ya
-    body = body.replace(/<https?:\/\/[^\|]+?\|([^>]+?)>/g, '$1');
+    // hello @oddvar:http://oddvar.org how are ya
+    body = body.replace(/<(https?:\/\/[^\|]+?)\|[^>]+?>/g, '$1');
 
     // remove <> from links. if you post http://oddvar.org in slack,
     // this becomes <http://oddvar.org> in the event sent to Matrix


### PR DESCRIPTION
First commit keeps the URL of the file when you post a file. Example:
* before: `@U02DX4L9H uploaded a file: 2017-09-04-225512_1920x1080_scrot.png and commented: test`
* after: `@U02DX4L9H uploaded a file: https://iiens.slack.com/files/U02DX4L9H/F7B4WQXAM/trap.jpg and commented: lol`

If matrix users do not have an account on the slack server it does not help much, but if some have one they can click on the link to see the image.

The 2d commit fix the bug with `<>` (#43).