### PR TITLE
Translate slack messages to HTML

### DIFF
--- a/lib/SlackGhost.js
+++ b/lib/SlackGhost.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var rp = require('request-promise');
+var slackdown = require('slackdown');
 
 // How long in msec to cache avatar URL lookups from slack
 var AVATAR_CACHE_TIMEOUT = 10 * 60 * 1000;  // 10 minutes
@@ -122,7 +123,13 @@ SlackGhost.prototype.updateAvatar = function(message, room) {
 };
 
 SlackGhost.prototype.sendText = function(room_id, text) {
-    return this.getIntent().sendText(room_id, text).then(() => {
+    const content = {
+        body: text,
+        msgtype: "m.text",
+        formatted_body: slackdown.parse(text),
+        format: "org.matrix.custom.html"
+    };
+    return this.getIntent().sendMessage(room_id, content).then(() => {
         this._main.incCounter("sent_messages", {side: "matrix"});
     });
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "matrix-js-sdk": "^0.5",
     "minimist": "^1.2",
     "randomstring": "^1",
-    "slackdown": "^1.1"
+    "slackdown": "^0.1.1"
   },
   "devDependencies": {
     "eslint": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "matrix-appservice-bridge": "matrix-org/matrix-appservice-bridge#ca40ff5",
     "matrix-js-sdk": "^0.5",
     "minimist": "^1.2",
-    "randomstring": "^1"
+    "randomstring": "^1",
+    "slackdown": "^1.1"
   },
   "devDependencies": {
     "eslint": "^1.4.3",


### PR DESCRIPTION
Fix #44. Actually Slack does not use markdown, but its own format.