### PR TITLE
Allow syncing Bot messages from Slack to Matrix

### DIFF
--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -189,6 +189,10 @@ BridgedRoom.prototype._handleSlackMessage = function(message, ghost) {
         var text = substitutions.slackToMatrix(message.text);
         return ghost.sendText(roomID, text);
     }
+    else if (subtype === "bot_message") {
+        var text = substitutions.slackToMatrix(message.text);
+        return ghost.sendText(roomID, text);
+    }
     else if (subtype === "me_message") {
         var message = {
             msgtype: "m.emote",


### PR DESCRIPTION
This is untested! (I have no HS access to test but it is according to the slack Spec https://api.slack.com/events/message/bot_message )

This should fix #42 but as said I am not able to test it myself