### PR TITLE
Change @channel to @room

### DIFF
--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -62,6 +62,9 @@ var slackToMatrix = function(body) {
         }
     }
 
+    // convert @channel to @room
+    body = body.replace("<!channel>", "@room");
+
     // escape slack-links e.g:
     // "hello @oddvar:<http://oddvar.org|oddvar.org> how are ya"
     // becomes
@@ -116,6 +119,9 @@ var matrixToSlack = function(event, main) {
             string = "_" + string + "_";
         }
     }
+
+    // convert @room to @channel
+    string = string.replace("@room", "@channel");
 
     // the link_names flag means that writing @username will act as a mention in slack
     var ret = {


### PR DESCRIPTION
While you might not always want `@channel` in slack to notify you having it come through as `@room` is the matrix way, and it's what power levels are for :laughing: 