### PR TITLE
Don't pin on matrix-appservice-bridge anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "bluebird": "^3",
     "request-promise": "^3.0.0",
-    "matrix-appservice-bridge": "matrix-org/matrix-appservice-bridge#ca40ff5",
+    "matrix-appservice-bridge": "^1.4.0",
     "matrix-js-sdk": "^0.5",
     "minimist": "^1.2",
     "randomstring": "^1",


### PR DESCRIPTION
The pin was so we could get the prometheus client on the bridge, but that has since been merged. This also contains a bug fix for ``_isRemoteUser`` which means our DM invite rejections will work.