### PR TITLE
Allow deep paths to handle incoming hooks

### DIFF
--- a/lib/SlackHookHandler.js
+++ b/lib/SlackHookHandler.js
@@ -97,7 +97,7 @@ SlackHookHandler.prototype.handle = function(method, url, params, response) {
 
     var endTimer = main.startTimer("remote_request_seconds");
 
-    var result = url.match(/^\/(.{32})(?:\/(.*))?$/);
+    var result = url.match(/^.*?\/(.{32})(?:\/(.*))?$/);
     if (!result) {
         console.log("Ignoring message with bad slackhook URL " + url);
 


### PR DESCRIPTION
This allows the service to handle hooks sent to deep paths, i.e., `/services/matrix/:id` — useful when routing a single public domain to multiple bridges.