### PR TITLE
A whole bunch of hacks and improvements

### DIFF
--- a/config/slack-config-schema.yaml
+++ b/config/slack-config-schema.yaml
@@ -1,6 +1,8 @@
 type: object
 required: ["homeserver", "slack_hook_port", "inbound_uri_prefix", "bot_username", "username_prefix"]
 properties:
+  dbdir:
+    type: string
   homeserver:
     type: object
     required: ["server_name", "url"]

--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -238,6 +238,79 @@ BridgedRoom.prototype.onSlackMessage = function(message) {
     });
 };
 
+
+// These functions are copied and modified from the Gitter AS
+// idx counts backwards from the end of the string; 0 is final character
+function rcharAt(s,idx) { return s.charAt(s.length-1 - idx); }
+
+function firstWord(s) {
+    var groups = s.match(/^\s*\S+/);
+    return groups ? groups[0] : "";
+}
+
+function finalWord(s) {
+    var groups = s.match(/\S+\s*$/);
+    return groups ? groups[0] : "";
+}
+
+function htmlEscape(s) {
+    return s.replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+}
+
+function makeDiff(prev, curr) {
+    var i;
+    for (i = 0; i < curr.length && i < prev.length; i++) {
+        if (curr.charAt(i) != prev.charAt(i)) break;
+    }
+    // retreat to the start of a word
+    while(i > 0 && /\S/.test(curr.charAt(i-1))) i--;
+
+    var prefixLen = i;
+
+    for(i = 0; i < curr.length && i < prev.length; i++) {
+        if (rcharAt(curr, i) != rcharAt(prev, i)) break;
+    }
+    // advance to the end of a word
+    while(i > 0 && /\S/.test(rcharAt(curr, i-1))) i--;
+
+    var suffixLen = i;
+
+    // Extract the common prefix and suffix strings themselves and
+    //   mutate the prev/curr strings to only contain the differing
+    //   middle region
+    var prefix = curr.slice(0, prefixLen);
+    curr = curr.slice(prefixLen);
+    prev = prev.slice(prefixLen);
+
+    var suffix = "";
+    if (suffixLen > 0) {
+        suffix = curr.slice(-suffixLen);
+        curr = curr.slice(0, -suffixLen);
+        prev = prev.slice(0, -suffixLen);
+    }
+
+    // At this point, we have four strings; the common prefix and
+    //   suffix, and the edited middle part. To display it nicely as a
+    //   matrix message we'll use the final word of the prefix and the
+    //   first word of the suffix as "context" for a customly-formatted
+    //   message.
+
+    var before = finalWord(prefix);
+    if (before != prefix) { before = "... " + before; }
+
+    var after = firstWord(suffix);
+    if (after != suffix) { after = after + " ..."; }
+
+    // return {prev: prev,
+    //         curr: curr,
+    //         before: before,
+    //         after: after};
+    return {prev, curr, before, after};
+}
+
+
 BridgedRoom.prototype._handleSlackMessage = function(message, ghost) {
     var roomID = this.getMatrixRoomId();
 
@@ -261,7 +334,44 @@ BridgedRoom.prototype._handleSlackMessage = function(message, ghost) {
         };
         return ghost.sendMessage(roomID, message);
     }
-    else if (message.files) {
+    else if (subtype === "message_changed") {
+        var previous_message = substitutions.slackToMatrix(message.previous_message.text);
+        var new_message = substitutions.slackToMatrix(message.message.text);
+
+        // The substitutions might make the messages the same
+        if (previous_message === new_message) {
+            console.log("Ignoring edit message because messages are the same post-substitutions.");
+            return;
+        }
+
+        var edits = makeDiff(previous_message, new_message);
+
+        var outtext = "(edited) " +
+            edits.before + edits.prev + edits.after + " => " +
+            edits.before + edits.curr + edits.after;
+
+        var prev   = htmlEscape(edits.prev);
+        var curr   = htmlEscape(edits.curr);
+        var before = htmlEscape(edits.before);
+        var after  = htmlEscape(edits.after);
+
+        var formatted = "<i>(edited)</i> " + before + '<font color="red">' + prev + '</font>' + after + " =&gt; " +
+        before + '<font color="green">' + curr + '</font>' + after;
+
+        var matrixcontent = {
+            body: outtext,
+            msgtype: "m.text",
+            formatted_body: formatted,
+            format: "org.matrix.custom.html"
+        };
+
+        return ghost.sendMessage(roomID, matrixcontent);
+    }
+    else if (subtype === "file_comment") {
+        var text = substitutions.slackToMatrix(message.text, message.file);
+        return ghost.sendText(roomID, text);
+    }
+    else if (message.files != undefined) {
         for (var i = 0; i < message.files.length; i++) {
             const file = message.files[i];
             // We also need to upload the thumbnail

--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -2,6 +2,7 @@
 
 var Promise = require('bluebird');
 
+var url = require('url');
 var substitutions = require("./substitutions");
 var rp = require('request-promise');
 const log = require("matrix-appservice-bridge").Logging.get("BridgedRoom");
@@ -374,39 +375,80 @@ BridgedRoom.prototype._handleSlackMessage = function(message, ghost) {
     else if (message.files != undefined) {
         for (var i = 0; i < message.files.length; i++) {
             const file = message.files[i];
-            // We also need to upload the thumbnail
-            let thumbnail_promise = Promise.resolve();
-            // Slack ain't a believer in consistency.
-            const thumb_uri = file.thumb_video || file.thumb_360;
-            if (thumb_uri) {
-                thumbnail_promise = ghost.uploadContentFromURI(
-                    {
-                        // Yes, we hardcode jpeg. Slack always use em.
-                        title: `${file.name}_thumb.jpeg`,
-                        mimetype: "image/jpeg",
-                    },
-                    thumb_uri,
-                    this._slack_bot_token
-                );
+            if (file.mode === "snippet") {
+                var options = url.parse(file.url_private);
+                options.headers = {
+                    Authorization: 'Bearer ' + this._slack_bot_token
+                };
+                const req = https.get(options, (res) => {
+                    let buffer = '';
+
+                    res.on("data", (d) => {
+                        buffer += d;
+                    });
+
+                    res.on("end", () => {
+                        var code = '```';
+                        code += '\n';
+                        code += buffer;
+                        code += '\n';
+                        code += '```';
+                        if (file.filetype) {
+                            var html_code = '<pre><code class="language-' + file.filetype + '">';
+                        }
+                        else {
+                            var html_code = '<pre><code>';
+                        }
+                        html_code += substitutions.htmlEscape(buffer);
+                        html_code += '</code></pre>';
+
+                        const content = {
+                            body: code,
+                            msgtype: "m.text",
+                            formatted_body: html_code,
+                            format: "org.matrix.custom.html"
+                        };
+                        return ghost.sendMessage(roomID, content);
+                    });
+                });
+                req.on("error", (err) => {
+                    reject("Failed to download");
+                });
             }
-            let content_uri = "";
-            return ghost.uploadContentFromURI(file, file.url_private, this._slack_bot_token)
-            .then((file_content_uri) => {
-                content_uri = file_content_uri;
-                return thumbnail_promise;
-            }).then((thumb_content_uri) => {
-                return ghost.sendMessage(
-                    roomID,
-                    slackFileToMatrixMessage(file, content_uri, thumb_content_uri)
-                );
-            }).then(() => {
-                // TODO: Currently Matrix lacks a way to upload a "captioned image",
-                //   so we just send a separate `m.image` and `m.text` message
-                // See https://github.com/matrix-org/matrix-doc/issues/906
-                if (message.text) {
-                    return ghost.sendText(roomID, message.text);
+            else {
+                // We also need to upload the thumbnail
+                let thumbnail_promise = Promise.resolve();
+                // Slack ain't a believer in consistency.
+                const thumb_uri = file.thumb_video || file.thumb_360;
+                if (thumb_uri) {
+                    thumbnail_promise = ghost.uploadContentFromURI(
+                        {
+                            // Yes, we hardcode jpeg. Slack always use em.
+                            title: `${file.name}_thumb.jpeg`,
+                            mimetype: "image/jpeg",
+                        },
+                        thumb_uri,
+                        this._slack_bot_token
+                    );
                 }
-            });
+                let content_uri = "";
+                return ghost.uploadContentFromURI(file, file.url_private, this._slack_bot_token)
+                .then((file_content_uri) => {
+                    content_uri = file_content_uri;
+                    return thumbnail_promise;
+                }).then((thumb_content_uri) => {
+                    return ghost.sendMessage(
+                        roomID,
+                        slackFileToMatrixMessage(file, content_uri, thumb_content_uri)
+                    );
+                }).then(() => {
+                    // TODO: Currently Matrix lacks a way to upload a "captioned image",
+                    //   so we just send a separate `m.image` and `m.text` message
+                    // See https://github.com/matrix-org/matrix-doc/issues/906
+                    if (message.text) {
+                        return ghost.sendText(roomID, message.text);
+                    }
+                });
         }
     }
     else {

--- a/lib/Main.js
+++ b/lib/Main.js
@@ -50,10 +50,13 @@ function Main(config) {
     // So we can't create the StateLookup instance yet
     this._stateStorage = null;
 
+    var dbdir = config.dbdir || "";
     this._bridge = new Bridge({
         homeserverUrl: config.homeserver.url,
         domain: config.homeserver.server_name,
         registration: "slack-registration.yaml",
+        userStore: dbdir + "user-store.db",
+        roomStore: dbdir + "room-store.db",
 
         controller: {
             onUserQuery: function(queriedUser) {

--- a/lib/Main.js
+++ b/lib/Main.js
@@ -191,6 +191,10 @@ Main.prototype.getBotIntent = function() {
     return this._bridge.getIntent();
 };
 
+Main.prototype.getUsernamePrefix = function() {
+    return this._config.username_prefix;
+};
+
 Main.prototype.getTeamDomainForMessage = function(message) {
     if (message.team_domain) {
         return Promise.resolve(message.team_domain);

--- a/lib/SlackEventHandler.js
+++ b/lib/SlackEventHandler.js
@@ -161,10 +161,15 @@ SlackEventHandler.prototype.handleMessageEvent = function (params) {
         channel_id: params.event.channel
     });
 
-    var processMsg = msg.text || msg.subtype === 'message_deleted' || msg.files != undefined;
+    var processMsg = msg.text || msg.subtype === 'message_deleted' || msg.files != undefined || msg.subtype === 'message_changed';
 
     if (msg.subtype === 'file_comment') {
         msg.user_id = msg.comment.user;
+    }
+    // Make a message_changed look a little more like a normal message.
+    else if (msg.subtype === "message_changed") {
+        msg.user_id = msg.message.user;
+        msg.text = msg.message.text;
     }
 
     if (!token) {

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -122,7 +122,6 @@ var matrixToSlack = function(event, main) {
     var string = event.content.body;
 
     // remove <> from links, e.g:
-    //
     string = string.replace(/<((https?:\/\/)?[^>]+?)>/g, '$1');
 
     if (undefined != string) {
@@ -140,11 +139,14 @@ var matrixToSlack = function(event, main) {
         if (undefined != html_string) {
             var regex = new RegExp('<a href="https://matrix.to/#/@' +
                                    main.getUsernamePrefix() +
-                                   '[^"]+">([^<]+)</a>', "g");
+                                   '([^"]+)">([^<]+)</a>', "g");
 
             var match = regex.exec(html_string);
             while (match != null) {
-                string = string.replace(match[1], "@" + match[1]);
+                // Extract the slack ID from the matrix id
+                var userid = match[1].split("_")[1].split(":")[0];
+                // Construct the new slack mention
+                string = string.replace(match[2], "<@" + userid + ">");
                 match = regex.exec(html_string);
             }
         }

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -134,6 +134,20 @@ var matrixToSlack = function(event, main) {
         if (event.content.msgtype == "m.emote") {
             string = "_" + string + "_";
         }
+
+        // replace riot "pill" behavior to "@" mention for slack users
+        var html_string = event.content.formatted_body;
+        if (undefined != html_string) {
+            var regex = new RegExp('<a href="https://matrix.to/#/@' +
+                                   main.getUsernamePrefix() +
+                                   '[^"]+">([^<]+)</a>', "g");
+
+            var match = regex.exec(html_string);
+            while (match != null) {
+                string = string.replace(match[1], "@" + match[1]);
+                match = regex.exec(html_string);
+            }
+        }
     }
 
     // convert @room to @channel


### PR DESCRIPTION
I can spiit this up into multiple bits, but I have tried to keep the commit history tidy. This does:

Now in #92:
* ~Does some html escaping~
* ~**Fixes file bridging because the slack API changed**~
* ~Strips out the language specifiers in triple backticks because they don't render on slack correctly.~

In this PR once #92 is merged:
* Improves pills substitutions to use the new slack mentions
* Add Gitter style edit bridging
* Adds a config option to specify the directory the `user-store.db` and `room-store.db` files go in
* Converts slack snippets to inline code dumps in matrix
