### PR TITLE
Implement bridging of plain text matrix mentions

### DIFF
--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -192,9 +192,9 @@ BridgedRoom.prototype.onMatrixMessage = function(message) {
 
     return this._main.getOrCreateMatrixUser(message.user_id).then((user) => {
         substitutions.matrixToSlack(message, this._main).then(body => {
-            var uri = (this._slack_bot_token) ? "https://slack.com/api/chat.postMessage" : this._slack_webhook_uri;
+            const uri = (this._slack_bot_token) ? "https://slack.com/api/chat.postMessage" : this._slack_webhook_uri;
 
-            var sendMessageParams = {
+            const sendMessageParams = {
                 method: "POST",
                 json: true,
                 uri: uri,
@@ -211,7 +211,7 @@ BridgedRoom.prototype.onMatrixMessage = function(message) {
 
             sendMessageParams.body.username = user.getDisplaynameForRoom(message.room_id);
 
-            var avatar_url = user.getAvatarUrlForRoom(message.room_id);
+            const avatar_url = user.getAvatarUrlForRoom(message.room_id);
 
             if (avatar_url && avatar_url.indexOf("mxc://") === 0) {
                 sendMessageParams.body.icon_url = this._main.getUrlForMxc(avatar_url);

--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -192,8 +192,6 @@ BridgedRoom.prototype.onMatrixMessage = function(message) {
 
     return this._main.getOrCreateMatrixUser(message.user_id).then((user) => {
         substitutions.matrixToSlack(message, this._main).then(body => {
-            var body = substitutions.matrixToSlack(message, this._main);
-
             var uri = (this._slack_bot_token) ? "https://slack.com/api/chat.postMessage" : this._slack_webhook_uri;
 
             var sendMessageParams = {
@@ -219,8 +217,8 @@ BridgedRoom.prototype.onMatrixMessage = function(message) {
                 sendMessageParams.body.icon_url = this._main.getUrlForMxc(avatar_url);
             }
 
-        user.bumpATime();
-        this._matrixAtime = Date.now() / 1000;
+            user.bumpATime();
+            this._matrixAtime = Date.now() / 1000;
 
             return rp(sendMessageParams).then((res) => {
                 this._main.incCounter("sent_messages", {side: "remote"});

--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -191,41 +191,43 @@ BridgedRoom.prototype.onMatrixMessage = function(message) {
     if (!this._slack_webhook_uri && !this._slack_bot_token) return Promise.resolve();
 
     return this._main.getOrCreateMatrixUser(message.user_id).then((user) => {
-        var body = substitutions.matrixToSlack(message, this._main);
+        substitutions.matrixToSlack(message, this._main).then(body => {
+            var body = substitutions.matrixToSlack(message, this._main);
 
-        var uri = (this._slack_bot_token) ? "https://slack.com/api/chat.postMessage" : this._slack_webhook_uri;
+            var uri = (this._slack_bot_token) ? "https://slack.com/api/chat.postMessage" : this._slack_webhook_uri;
 
-        var sendMessageParams = {
-            method: "POST",
-            json: true,
-            uri: uri,
-            body: body,
-        };
-        if (this._slack_bot_token) {
-            sendMessageParams.headers = {
-                Authorization: 'Bearer ' + this._slack_bot_token
+            var sendMessageParams = {
+                method: "POST",
+                json: true,
+                uri: uri,
+                body: body,
             };
-            // See https://api.slack.com/methods/chat.postMessage#authorship
-            sendMessageParams.body.as_user = false;
-            sendMessageParams.body.channel = this._slack_channel_id;
-        }
+            if (this._slack_bot_token) {
+                sendMessageParams.headers = {
+                    Authorization: 'Bearer ' + this._slack_bot_token
+                };
+                // See https://api.slack.com/methods/chat.postMessage#authorship
+                sendMessageParams.body.as_user = false;
+                sendMessageParams.body.channel = this._slack_channel_id;
+            }
 
-        sendMessageParams.body.username = user.getDisplaynameForRoom(message.room_id);
+            sendMessageParams.body.username = user.getDisplaynameForRoom(message.room_id);
 
-        var avatar_url = user.getAvatarUrlForRoom(message.room_id);
+            var avatar_url = user.getAvatarUrlForRoom(message.room_id);
 
-        if (avatar_url && avatar_url.indexOf("mxc://") === 0) {
-            sendMessageParams.body.icon_url = this._main.getUrlForMxc(avatar_url);
-        }
+            if (avatar_url && avatar_url.indexOf("mxc://") === 0) {
+                sendMessageParams.body.icon_url = this._main.getUrlForMxc(avatar_url);
+            }
 
         user.bumpATime();
         this._matrixAtime = Date.now() / 1000;
 
-        return rp(sendMessageParams).then((res) => {
-            this._main.incCounter("sent_messages", {side: "remote"});
-            if (!res) {
-                log.error("Outgoing message HTTP error: %s", res);
-            }
+            return rp(sendMessageParams).then((res) => {
+                this._main.incCounter("sent_messages", {side: "remote"});
+                if (!res || !res.ok) {
+                    log.error("HTTP Error: ", res);
+                }
+            });
         });
     });
 };

--- a/lib/SlackGhost.js
+++ b/lib/SlackGhost.js
@@ -3,7 +3,7 @@
 var url = require('url');
 var https = require('https');
 var rp = require('request-promise');
-const Slackdown = require('Slackdown');
+const slackdown = require('Slackdown');
 const substitutions = require("./substitutions");
 const log = require("matrix-appservice-bridge").Logging.get("SlackGhost");
 

--- a/lib/SlackGhost.js
+++ b/lib/SlackGhost.js
@@ -3,7 +3,7 @@
 var url = require('url');
 var https = require('https');
 var rp = require('request-promise');
-const slackdown = require('Slackdown');
+const Slackdown = require('Slackdown');
 const substitutions = require("./substitutions");
 const log = require("matrix-appservice-bridge").Logging.get("SlackGhost");
 
@@ -165,7 +165,7 @@ SlackGhost.prototype.sendText = function(room_id, text) {
     const content = {
         body: text,
         msgtype: "m.text",
-        formatted_body: slackdown.parse(text),
+        formatted_body: Slackdown.parse(text),
         format: "org.matrix.custom.html"
     };
     return this.getIntent().sendMessage(room_id, content).then(() => {

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -152,6 +152,61 @@ var matrixToSlack = function(event, main) {
         }
     }
 
+    // attempts at nickname lookup
+
+    // If @ in message:
+    var store = main.getUserStore();
+    main.listGhostUsers(event.room_id)
+        .then(users => Promise.all(users.map(user => store.select({id: user}))))
+        .then(users => {
+            var displaymap = {};
+            users.forEach(user => {
+                if (user && user[0]) {
+                    displaymap[user[0].display_name] = user[0].id.split("_")[2].split(":")[0];
+                }
+            });
+
+            // Now construct a grouped map like this, so that we can match based on first word after @
+            // {"bob": [{"bob": "U123123"}, {"bob smith": "U2891283"}]}
+            var displaynames = Object.keys(displaymap);
+            var firstwords = {};
+        
+            for (var i=0; i < displaynames.length; i++) {
+                var dispname = displaynames[i];
+                var firstword = dispname.split(" ");
+                var amap = {};
+                amap[dispname] = displaymap[dispname];
+                if (firstwords.hasOwnProperty(dispname)) {
+                    firstwords[firstword].push(amap);
+                }
+                else {
+                    firstwords[firstword] = [amap];
+                }
+            }
+            console.log(firstwords);
+
+            // Now parse the message and extract the first word after the @
+            var matches = string.match(/(@\w+)/g);
+            if (matches) {
+                for (var i=0; i < matches.length; i++) {
+                    match = matches[i];
+                    firstword = match.replace("@", "");
+                    if (firstwords.hasOwnProperty(firstword)) {
+                        var nicks = firstwords[firstword];
+                        console.log("nicks: " + JSON.stringify(nicks));
+                        if (nicks.length === 1) {
+                            var userid = nicks[0][firstword];
+                            console.log(string.replace(match, "<@" + userid + ">"));
+                        }
+                        else {
+                            // Do something to match the longest nick.
+                        }
+                    }
+                }
+            }
+        });
+
+
     // convert @room to @channel
     string = string.replace("@room", "@channel");
 

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -152,61 +152,8 @@ var matrixToSlack = function(event, main) {
         }
     }
 
-    // attempts at nickname lookup
-
-    // If @ in message:
-    var store = main.getUserStore();
-    main.listGhostUsers(event.room_id)
-        .then(users => Promise.all(users.map(user => store.select({id: user}))))
-        .then(users => {
-            var displaymap = {};
-            users.forEach(user => {
-                if (user && user[0]) {
-                    displaymap[user[0].display_name] = user[0].id.split("_")[2].split(":")[0];
-                }
-            });
-
-            // Now construct a grouped map like this, so that we can match based on first word after @
-            // {"bob": [{"bob": "U123123"}, {"bob smith": "U2891283"}]}
-            var displaynames = Object.keys(displaymap);
-            var firstwords = {};
-        
-            for (var i=0; i < displaynames.length; i++) {
-                var dispname = displaynames[i];
-                var firstword = dispname.split(" ");
-                var amap = {};
-                amap[dispname] = displaymap[dispname];
-                if (firstwords.hasOwnProperty(dispname)) {
-                    firstwords[firstword].push(amap);
-                }
-                else {
-                    firstwords[firstword] = [amap];
-                }
-            }
-            console.log(firstwords);
-
-            // Now parse the message and extract the first word after the @
-            var matches = string.match(/(@\w+)/g);
-            if (matches) {
-                for (var i=0; i < matches.length; i++) {
-                    match = matches[i];
-                    firstword = match.replace("@", "");
-                    if (firstwords.hasOwnProperty(firstword)) {
-                        var nicks = firstwords[firstword];
-                        console.log("nicks: " + JSON.stringify(nicks));
-                        if (nicks.length === 1) {
-                            var userid = nicks[0][firstword];
-                            console.log(string.replace(match, "<@" + userid + ">"));
-                        }
-                        else {
-                            // Do something to match the longest nick.
-                        }
-                    }
-                }
-            }
-        });
-
-
+    plainTextSlackMentions(main, string, event.room_id);
+    
     // convert @room to @channel
     string = string.replace("@room", "@channel");
 
@@ -239,6 +186,100 @@ var htmlEscape = function(s) {
         .replace(/</g, "&lt;")
         .replace(/>/g, "&gt;");
 };
+
+/**
+ * Get a mapping of the nicknames of all Slack Ghosts in the room to their slack user ids.
+ *
+ * @param {String} room_id The room id to make the maps for.
+ * @return {Promise} A mapping of display name to slack user id.
+ */
+function getDisplayMap(main, room_id) {
+    var store = main.getUserStore();
+    return main.listGhostUsers(room_id)
+        .then(users => Promise.all(users.map(user => store.select({id: user}))))
+        .then(users => {
+            var displaymap = {};
+            users.forEach(user => {
+                if (user && user[0]) {
+                    displaymap[user[0].display_name] = user[0].id.split("_")[2].split(":")[0];
+                }
+            });
+            return displaymap;
+        });
+}
+
+/**
+ * Construct a mapping of the first words of all the display names to
+ * an array of objects which map full display names to their slack 
+ * user ids.
+ * i.e. {"bob": [{"bob": "U123123"}, {"bob smith": "U2891283"}]}
+ *
+ * @param {Object} displaymap A mapping of display names to slack user ids.
+ * @return {Object} A mapping of first words of display names.
+ */
+function makeFirstWordMap(displaymap) {
+    var displaynames = Object.keys(displaymap);
+    var firstwords = {};
+
+    for (const dispname of displaynames) {
+        var firstword = dispname.split(" ");
+        var amap = {};
+        amap[dispname] = displaymap[dispname];
+        if (firstwords.hasOwnProperty(dispname)) {
+            firstwords[firstword].push(amap);
+        }
+        else {
+            firstwords[firstword] = [amap];
+        }
+    }
+    return firstwords;
+}
+
+
+/**
+ * Do string replacement on a message given the display map.
+ *
+ * @param {String} string The string to perform replacements on.
+ * @param {Object} displaymap A mapping of display names to slack user ids.
+ * @return {String} The string with replacements performed.
+ */
+function replacementFromDisplayMap(string, displaymap) {
+    var firstwords = makeFirstWordMap(displaymap);
+
+    // Now parse the message and extract the first word after the @
+    var matches = string.match(/(@\w+)/g);
+    if (matches && matches.length) {
+        for (const match of matches) {
+            var firstword = match.replace("@", "");
+            if (firstwords.hasOwnProperty(firstword)) {
+                var nicks = firstwords[firstword];
+                if (nicks.length === 1) {
+                    var userid = nicks[0][firstword];
+                    string = string.replace(match, "<@" + userid + ">");
+                }
+                else {
+                    // Do something to match the longest nick.
+                }
+            }
+        }
+        console.log(string);
+        return string;
+    }
+}
+
+
+/**
+ * Replace plain text form of @displayname mentions with the slack mention syntax.
+ *
+ * @param {Main} main the toplevel main instance
+ * @param {String} string The string to perform replacements on.
+ * @param {String} room_id The room the message was sent in.
+ * @return {String} The string with replacements performed.
+ */
+function plainTextSlackMentions(main, string, room_id) {
+    return getDisplayMap(main, room_id).then(displaymap => replacementFromDisplayMap(string, displaymap));
+}
+
 
 
 // These functions are copied and modified from the Gitter AS

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var fs = require("fs");
+const fs = require("fs");
 const log = require("matrix-appservice-bridge").Logging.get("substitutions");
 
 // Ordered
@@ -152,7 +152,6 @@ var matrixToSlack = function(event, main) {
         }
     }
 
-    
     // convert @room to @channel
     string = string.replace("@room", "@channel");
 
@@ -163,7 +162,8 @@ var matrixToSlack = function(event, main) {
         var ret = {
             username: event.user_id,
             text: string,
-        }
+            link_names: 1  //This no longer works for nicks but is needed to make @channel work.
+        };
         if (event.content.msgtype == "m.image" && event.content.url.indexOf("mxc://") === 0) {
             var url = main.getUrlForMxc(event.content.url);
             delete ret.text;
@@ -245,31 +245,27 @@ function makeFirstWordMap(displaymap) {
 function replacementFromDisplayMap(string, displaymap) {
     const firstwords = makeFirstWordMap(displaymap);
 
-    // Now parse the message and extract the first word after the @
-
-    // TODO: If we changed this regex to be the union of the set containing all
-    // the keys in firstwords, and all the words in string, it would give us the
-    // set of first words present in the string, without having to regex match
-    // on @
-    const matches = string.match(/(@\w+)/g);
+    // Now parse the message to find the intersection of every word in the
+    // message with every first word of all nicks.
+    const match_words = new Set(Object.keys(firstwords));
+    const string_words = new Set(string.split(" "));
+    const matches = [...string_words].filter(x => match_words.has(x));
 
     if (matches && matches.length) {
-        for (const match of matches) {
-            const firstword = match.replace("@", "");
+        for (const firstword of matches) {
             if (firstwords.hasOwnProperty(firstword)) {
                 const nicks = firstwords[firstword];
                 if (nicks.length === 1) {
-                    string = string.replace(match, "<@" + nicks[0][firstword] + ">");
+                    string = string.replace(firstword, "<@" + nicks[0][firstword] + ">");
                 }
                 else {
-                    // Sort the displaynames by longest string first, and then match the first one.
+                    // Sort the displaynames by longest string first, and then match them from longest to shortest.
+                    // This can match multiple times if there is more than one mention in the message
                     const displaynames = nicks.map(x => Object.keys(x)[0]);
                     displaynames.sort((x, y) => y.length - x.length);
                     for (const displayname of displaynames) {
-                        const replacement = "@" + displayname
-                        if (string.includes(replacement)) {
-                            string = string.replace(replacement, "<@" + displaymap[displayname] + ">");
-                            break;
+                        if (string.includes(displayname)) {
+                            string = string.replace(displayname, "<@" + displaymap[displayname] + ">");
                         }
                     }
                 }

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -161,20 +161,20 @@ var matrixToSlack = function(event, main) {
     // Note: This slower plainTextSlackMentions call is only used if there is not a pill in the message,
     // meaning if we can we use the much simpler pill subs rather than this.
     return plainTextSlackMentions(main, string, event.room_id).then(string => {
-        var ret = {
+        const ret = {
             username: event.user_id,
             text: string,
             link_names: 1  //This no longer works for nicks but is needed to make @channel work.
         };
         if (event.content.msgtype == "m.image" && event.content.url.indexOf("mxc://") === 0) {
-            var url = main.getUrlForMxc(event.content.url);
+            const url = main.getUrlForMxc(event.content.url);
             delete ret.text;
             ret.attachments = [{
                 fallback: string,
                 image_url: url
             }];
         } else if (event.content.msgtype == "m.file" && event.content.url.indexOf("mxc://") === 0) {
-            var url = main.getUrlForMxc(event.content.url);
+            const url = main.getUrlForMxc(event.content.url);
             ret.text = "<" + url + "|" + string + ">";
         }
 

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -193,11 +193,11 @@ var htmlEscape = function(s) {
  * @return {Promise} A mapping of display name to slack user id.
  */
 function getDisplayMap(main, room_id) {
-    var store = main.getUserStore();
+    const store = main.getUserStore();
     return main.listGhostUsers(room_id)
         .then(users => Promise.all(users.map(user => store.select({id: user}))))
         .then(users => {
-            var displaymap = {};
+            const displaymap = {};
             users.forEach(user => {
                 if (user && user[0]) {
                     displaymap[user[0].display_name] = user[0].id.split("_")[2].split(":")[0];
@@ -217,12 +217,12 @@ function getDisplayMap(main, room_id) {
  * @return {Object} A mapping of first words of display names.
  */
 function makeFirstWordMap(displaymap) {
-    var displaynames = Object.keys(displaymap);
-    var firstwords = {};
+    const displaynames = Object.keys(displaymap);
+    const firstwords = {};
 
     for (const dispname of displaynames) {
-        var firstword = dispname.split(" ")[0];
-        var amap = {};
+        const firstword = dispname.split(" ")[0];
+        const amap = {};
         amap[dispname] = displaymap[dispname];
         if (firstwords.hasOwnProperty(firstword)) {
             firstwords[firstword].push(amap);
@@ -243,25 +243,24 @@ function makeFirstWordMap(displaymap) {
  * @return {String} The string with replacements performed.
  */
 function replacementFromDisplayMap(string, displaymap) {
-    var firstwords = makeFirstWordMap(displaymap);
+    const firstwords = makeFirstWordMap(displaymap);
 
     // Now parse the message and extract the first word after the @
-    var matches = string.match(/(@\w+)/g);
+    const matches = string.match(/(@\w+)/g);
     if (matches && matches.length) {
         for (const match of matches) {
-            var firstword = match.replace("@", "");
+            const firstword = match.replace("@", "");
             if (firstwords.hasOwnProperty(firstword)) {
-                var nicks = firstwords[firstword];
+                const nicks = firstwords[firstword];
                 if (nicks.length === 1) {
-                    var userid = nicks[0][firstword];
-                    string = string.replace(match, "<@" + userid + ">");
+                    string = string.replace(match, "<@" + nicks[0][firstword] + ">");
                 }
                 else {
                     // Do something to match the longest nick.
-                    var displaynames = nicks.map(x => Object.keys(x)[0]);
+                    const displaynames = nicks.map(x => Object.keys(x)[0]);
                     displaynames.sort((x, y) => y.length - x.length);
-                    for (var displayname of displaynames) {
-                        var replacement = "@" + displayname
+                    for (const displayname of displaynames) {
+                        const replacement = "@" + displayname
                         if (string.includes(replacement)) {
                             string = string.replace(replacement, "<@" + displaymap[displayname] + ">");
                         }

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -222,10 +222,10 @@ function makeFirstWordMap(displaymap) {
     var firstwords = {};
 
     for (const dispname of displaynames) {
-        var firstword = dispname.split(" ");
+        var firstword = dispname.split(" ")[0];
         var amap = {};
         amap[dispname] = displaymap[dispname];
-        if (firstwords.hasOwnProperty(dispname)) {
+        if (firstwords.hasOwnProperty(firstword)) {
             firstwords[firstword].push(amap);
         }
         else {
@@ -259,10 +259,17 @@ function replacementFromDisplayMap(string, displaymap) {
                 }
                 else {
                     // Do something to match the longest nick.
+                    var displaynames = nicks.map(x => Object.keys(x)[0]);
+                    displaynames.sort((x, y) => y.length - x.length);
+                    for (var displayname of displaynames) {
+                        var replacement = "@" + displayname
+                        if (string.includes(replacement)) {
+                            string = string.replace(replacement, "<@" + displaymap[displayname] + ">");
+                        }
+                    }
                 }
             }
         }
-        console.log(string);
         return string;
     }
 }
@@ -354,5 +361,7 @@ module.exports = {
     slackToMatrix: slackToMatrix,
     getSlackFileUrl: getSlackFileUrl,
     htmlEscape: htmlEscape,
+    replacementFromDisplayMap: replacementFromDisplayMap,
+    makeFirstWordMap: makeFirstWordMap,
     makeDiff: makeDiff
 };

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -152,7 +152,6 @@ var matrixToSlack = function(event, main) {
         }
     }
 
-    plainTextSlackMentions(main, string, event.room_id);
     
     // convert @room to @channel
     string = string.replace("@room", "@channel");
@@ -160,26 +159,26 @@ var matrixToSlack = function(event, main) {
     // Strip out any language specifier on the code tags, as they are not supported by slack.
     string = string.replace(/```[\w*]+\n/g, "```\n");
 
-    // the link_names flag means that writing @username will act as a mention in slack
-    var ret = {
-        username: event.user_id,
-        text: string,
-        link_names: 1
-    }
-    if (event.content.msgtype == "m.image" && event.content.url.indexOf("mxc://") === 0) {
-        var url = main.getUrlForMxc(event.content.url);
-        delete ret.text;
-        ret.attachments = [{
-            fallback: string,
-            image_url: url
-        }];
-    } else if (event.content.msgtype == "m.file" && event.content.url.indexOf("mxc://") === 0) {
-        var url = main.getUrlForMxc(event.content.url);
-        ret.text = "<" + url + "|" + string + ">";
-    }
+    return plainTextSlackMentions(main, string, event.room_id).then(string => {
+        var ret = {
+            username: event.user_id,
+            text: string,
+        }
+        if (event.content.msgtype == "m.image" && event.content.url.indexOf("mxc://") === 0) {
+            var url = main.getUrlForMxc(event.content.url);
+            delete ret.text;
+            ret.attachments = [{
+                fallback: string,
+                image_url: url
+            }];
+        } else if (event.content.msgtype == "m.file" && event.content.url.indexOf("mxc://") === 0) {
+            var url = main.getUrlForMxc(event.content.url);
+            ret.text = "<" + url + "|" + string + ">";
+        }
 
-    return ret;
-};
+        return ret;
+    });
+}
 
 var htmlEscape = function(s) {
     return s.replace(/&/g, "&amp;")
@@ -270,8 +269,8 @@ function replacementFromDisplayMap(string, displaymap) {
                 }
             }
         }
-        return string;
     }
+    return string;
 }
 
 

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -158,6 +158,8 @@ var matrixToSlack = function(event, main) {
     // Strip out any language specifier on the code tags, as they are not supported by slack.
     string = string.replace(/```[\w*]+\n/g, "```\n");
 
+    // Note: This slower plainTextSlackMentions call is only used if there is not a pill in the message,
+    // meaning if we can we use the much simpler pill subs rather than this.
     return plainTextSlackMentions(main, string, event.room_id).then(string => {
         var ret = {
             username: event.user_id,

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -246,7 +246,13 @@ function replacementFromDisplayMap(string, displaymap) {
     const firstwords = makeFirstWordMap(displaymap);
 
     // Now parse the message and extract the first word after the @
+
+    // TODO: If we changed this regex to be the union of the set containing all
+    // the keys in firstwords, and all the words in string, it would give us the
+    // set of first words present in the string, without having to regex match
+    // on @
     const matches = string.match(/(@\w+)/g);
+
     if (matches && matches.length) {
         for (const match of matches) {
             const firstword = match.replace("@", "");
@@ -256,13 +262,14 @@ function replacementFromDisplayMap(string, displaymap) {
                     string = string.replace(match, "<@" + nicks[0][firstword] + ">");
                 }
                 else {
-                    // Do something to match the longest nick.
+                    // Sort the displaynames by longest string first, and then match the first one.
                     const displaynames = nicks.map(x => Object.keys(x)[0]);
                     displaynames.sort((x, y) => y.length - x.length);
                     for (const displayname of displaynames) {
                         const replacement = "@" + displayname
                         if (string.includes(replacement)) {
                             string = string.replace(replacement, "<@" + displaymap[displayname] + ">");
+                            break;
                         }
                     }
                 }

--- a/tests/test-subsitutions.spec.js
+++ b/tests/test-subsitutions.spec.js
@@ -1,0 +1,27 @@
+var subsitutions = require("../lib/substitutions");
+
+describe ("Plain Text Mentions", () => {
+    var displaymap = {Stuart: "U1111", Cadair: "U2222", "Stuart Mumford": "U3333"}
+    it("replace unique nick", () => {
+        var new_string = subsitutions.replacementFromDisplayMap("@Cadair", displaymap);
+        expect(new_string).toBe("<@U2222>");
+    });
+    it("replace shortest non-unique", () => {
+        var new_string = subsitutions.replacementFromDisplayMap("@Stuart", displaymap);
+        expect(new_string).toBe("<@U1111>");
+    });
+    it("replace longest non-unique", () => {
+        var new_string = subsitutions.replacementFromDisplayMap("@Stuart Mumford", displaymap);
+        expect(new_string).toBe("<@U3333>");
+    });
+})
+
+describe ("Make First Word Map", () => {
+    var displaymap = {Stuart: "U1111", Cadair: "U2222", "Stuart Mumford": "U3333"}
+    var expectedfirstwords = {Stuart: [{Stuart: "U1111"}, {"Stuart Mumford": "U3333"}],
+                              Cadair: [{Cadair: "U2222"}]};
+    it("Make the First Word Map", () => {
+        var firstwords = subsitutions.makeFirstWordMap(displaymap);
+        expect(firstwords).toEqual(expectedfirstwords);
+    });
+})

--- a/tests/test-subsitutions.spec.js
+++ b/tests/test-subsitutions.spec.js
@@ -1,27 +1,27 @@
-var subsitutions = require("../lib/substitutions");
+const subsitutions = require("../lib/substitutions");
 
 describe ("Plain Text Mentions", () => {
-    var displaymap = {Stuart: "U1111", Cadair: "U2222", "Stuart Mumford": "U3333"}
+    const displaymap = {Stuart: "U1111", Cadair: "U2222", "Stuart Mumford": "U3333"}
     it("replace unique nick", () => {
-        var new_string = subsitutions.replacementFromDisplayMap("@Cadair", displaymap);
+        const new_string = subsitutions.replacementFromDisplayMap("@Cadair", displaymap);
         expect(new_string).toBe("<@U2222>");
     });
     it("replace shortest non-unique", () => {
-        var new_string = subsitutions.replacementFromDisplayMap("@Stuart", displaymap);
+        const new_string = subsitutions.replacementFromDisplayMap("@Stuart", displaymap);
         expect(new_string).toBe("<@U1111>");
     });
     it("replace longest non-unique", () => {
-        var new_string = subsitutions.replacementFromDisplayMap("@Stuart Mumford", displaymap);
+        const new_string = subsitutions.replacementFromDisplayMap("@Stuart Mumford", displaymap);
         expect(new_string).toBe("<@U3333>");
     });
 })
 
 describe ("Make First Word Map", () => {
-    var displaymap = {Stuart: "U1111", Cadair: "U2222", "Stuart Mumford": "U3333"}
-    var expectedfirstwords = {Stuart: [{Stuart: "U1111"}, {"Stuart Mumford": "U3333"}],
-                              Cadair: [{Cadair: "U2222"}]};
+    const displaymap = {Stuart: "U1111", Cadair: "U2222", "Stuart Mumford": "U3333"}
+    const expectedfirstwords = {Stuart: [{Stuart: "U1111"}, {"Stuart Mumford": "U3333"}],
+                                Cadair: [{Cadair: "U2222"}]};
     it("Make the First Word Map", () => {
-        var firstwords = subsitutions.makeFirstWordMap(displaymap);
+        const firstwords = subsitutions.makeFirstWordMap(displaymap);
         expect(firstwords).toEqual(expectedfirstwords);
     });
 })


### PR DESCRIPTION
The Slack API removed the ability to just send slack `@Cadair` text and have slack convert it into a mention. This is an attempt to do this substitution automatically in the bridge.

~~I would like to remove the need for the `@` here as well, which I have an idea how to do, but I am a little concerned about the performance impacts of all this.~~

This now correctly bridges plain text matrix mentions as slack mentions. This means that all matrix clients should give the correct behaviour on slack, making the bridge truly transparent. :tada: 

This also builds on #98 because of many many conflicts.