### PR TITLE
Remove slack link escaping because slackdown does it better

### DIFF
--- a/lib/SlackGhost.js
+++ b/lib/SlackGhost.js
@@ -162,8 +162,12 @@ SlackGhost.prototype.sendText = function(room_id, text) {
     // but the only parser we have for it is slackdown. However, Matrix expects
     // a variant of markdown that is in the realm of sanity. Currently text
     // will be slack's markdown until we've got a slack -> markdown parser.
+
+    //TODO: This is fixing plaintext mentions, but should be refactored. See issue #110
+    const theplaintext= text.replace(/<https:\/\/matrix\.to\/#\/@.+:.+\|(.+)>/g, "$1");
+
     const content = {
-        body: text,
+        body: theplaintext,
         msgtype: "m.text",
         formatted_body: Slackdown.parse(text),
         format: "org.matrix.custom.html"

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -67,17 +67,6 @@ var slackToMatrix = function(body, file) {
     // convert @channel to @room
     body = body.replace("<!channel>", "@room");
 
-    // escape slack-links e.g:
-    // "hello @oddvar:<http://oddvar.org|oddvar.org> how are ya"
-    // becomes
-    // hello @oddvar:http://oddvar.org how are ya
-    body = body.replace(/<(https?:\/\/[^\|]+?)\|[^>]+?>/g, '$1');
-
-    // remove <> from links. if you post http://oddvar.org in slack,
-    // this becomes <http://oddvar.org> in the event sent to Matrix
-    // so we need to strip <> from the link
-    body = body.replace(/<(https?:\/\/[^>]+?)>/g, '$1');
-
     // if we have a file, attempt to get the direct link to the file
     if (file && file.public_url_shared) {
         var url = getSlackFileUrl(file);


### PR DESCRIPTION
I think this is the best solution, it fixes the pills bug for me, and also seems to not break normal links.