### PR TITLE
Fix the discrepancy between nicks and names in pills and mentions

### DIFF
--- a/lib/BaseSlackHandler.js
+++ b/lib/BaseSlackHandler.js
@@ -98,14 +98,15 @@ BaseSlackHandler.prototype.replaceUserIdsWithNames = async function(message, tok
                 avatar_url: null});
             var room = main.getRoomBySlackChannelId(message.channel);
             display_name = await nullGhost.getDisplayName(id, room.getAccessToken());
-            user_id = main.getUserId(message.user_id, team_domain);
+            // If the user is not in the room, we cant pills them, we have to just plain text mention them.
+            message.text = message.text.replace(USER_ID_REGEX_FIRST, display_name);
         } else {
             display_name = users[0].display_name || user_id;
+            message.text = message.text.replace(
+                USER_ID_REGEX_FIRST,
+                `<https://matrix.to/#/${user_id}|${display_name}>`
+            );
         }
-        message.text = message.text.replace(
-            USER_ID_REGEX_FIRST,
-            `<https://matrix.to/#/${user_id}|${display_name}>`
-        );
         // Check for the next match.
         match = USER_ID_REGEX.exec(message.text);
     }

--- a/lib/BaseSlackHandler.js
+++ b/lib/BaseSlackHandler.js
@@ -4,6 +4,7 @@ const rp = require('request-promise');
 const Promise = require('bluebird');
 const promiseWhile = require("./promiseWhile");
 const getSlackFileUrl = require("./substitutions").getSlackFileUrl;
+const slackGhost = require("./SlackGhost");
 const log = require("matrix-appservice-bridge").Logging.get("BaseSlackHandler");
 
 const CHANNEL_ID_REGEX = /<#(\w+)\|?\w*?>/g;
@@ -69,84 +70,47 @@ BaseSlackHandler.prototype.replaceChannelIdsWithNames = function(message, token)
     });
 };
 
-BaseSlackHandler.prototype.replaceUserIdsWithNames = function(message, token) {
+BaseSlackHandler.prototype.replaceUserIdsWithNames = async function(message, token) {
     var main = this._main;
 
-    // match all userIds
-    var testForName = message.text.match(USER_ID_REGEX);
-    var iteration = 0;
-    var matches = 0;
-    if (testForName && testForName.length) {
-        matches = testForName.length;
-    }
-    return promiseWhile(() => {
-        // Condition for stopping
-        return iteration < matches;
-    }, function () {
+    let match = USER_ID_REGEX.exec(message.text);
+    while (match != null) {
         // foreach userId, pull out the ID
         // (if this is an emote msg, the format is <@ID|nick>, but in normal msgs it's just <@ID>
-        var id = testForName[iteration].match(USER_ID_REGEX_FIRST)[1];
-        var usersInfoApiParams = {
-            uri: 'https://slack.com/api/users.info',
-            qs: {
-                token: token,
-                user: id
-            },
-            json: true
-        };
-        main.incRemoteCallCounter("users.info");
-        let response;
-        iteration++;
-        return rp(usersInfoApiParams).then((res) => {
-            // Technically the function only requires the team_id, so
-            // pass in the response to get user instead.
-            // Though obviously don't if the response was wrong.
-            response = res;
-            return main.getTeamDomainForMessage(
-                {
-                    team_id: (res && res.user ? res.user : message).team_id,
-                    channel: message.channel,
-                }
-            );
-        }).then((team_domain) => {
-            const user_id = main.getUserId(id, team_domain);
-            if (response && response.user && response.user.name) {
-                log.info("users.info: " + id + " mapped to " + response.user.name);
-                const pill = `<https://matrix.to/#/${user_id}|${response.user.name}>`;
-                message.text = message.text.replace(
-                    USER_ID_REGEX_FIRST,
-                    pill
-                );
-                return;
-            }
-            log.warn(`users.info returned no result for ${id} Response:`, response);
-            // Fallback to checking the user store.
-            var store = this.getUserStore();
-            return store.select({id: user_id});
-        }).then((result) => {
-            if (result === undefined) {
-                return;
-            }
-            let name = user_id;
-            log.info(`${user_id} did ${result.length > 0 ? "not" : ""} an entry`);
-            if (result.length) {
-                // It's possible not to have a displayname set.
-                name = result[0].display_name || result[0].id;
-            }
-            message.text = message.text.replace(
-                USER_ID_REGEX_FIRST,
-                `<https://matrix.to/#/${user_id}|${name}>`
-            );
-        }).catch((err) => {
-            log.error("Caught error handing users.info: " + err);
-        });
-    }).then(() => {
-        // Notice we can chain it because it's a Promise,
-        // this will run after completion of the promiseWhile Promise!
-        return message;
-    });
-};
+        var id = match[0].match(USER_ID_REGEX_FIRST)[1];
 
+        const team_domain = await main.getTeamDomainForMessage(message);
+
+        let display_name = "";
+        let user_id = main.getUserId(id, team_domain);
+
+        const store = main.getUserStore();
+        const users = await store.select({id: user_id});
+
+        if (users === undefined || !users.length) {
+            log.warn("Mentioned user not in store. Looking up display name from slack.");
+            // if the user is not in the store then we look up the displayname
+            const nullGhost = new slackGhost({
+                main: main,
+                user_id: null,
+                intent: null,
+                display_name: null,
+                avatar_url: null});
+            var room = main.getRoomBySlackChannelId(message.channel);
+            display_name = await nullGhost.getDisplayName(id, room.getAccessToken());
+            user_id = main.getUserId(message.user_id, team_domain);
+        } else {
+            display_name = users[0].display_name || user_id;
+        }
+        message.text = message.text.replace(
+            USER_ID_REGEX_FIRST,
+            `<https://matrix.to/#/${user_id}|${display_name}>`
+        );
+        // Check for the next match.
+        match = USER_ID_REGEX.exec(message.text);
+    }
+    return message;
+}
 
 /**
  * Enables public sharing on the given file object. then fetches its content.

--- a/lib/BaseSlackHandler.js
+++ b/lib/BaseSlackHandler.js
@@ -77,7 +77,7 @@ BaseSlackHandler.prototype.replaceUserIdsWithNames = async function(message, tok
     while (match != null) {
         // foreach userId, pull out the ID
         // (if this is an emote msg, the format is <@ID|nick>, but in normal msgs it's just <@ID>
-        var id = match[0].match(USER_ID_REGEX_FIRST)[1];
+        const id = match[0].match(USER_ID_REGEX_FIRST)[1];
 
         const team_domain = await main.getTeamDomainForMessage(message);
 
@@ -91,7 +91,7 @@ BaseSlackHandler.prototype.replaceUserIdsWithNames = async function(message, tok
             log.warn("Mentioned user not in store. Looking up display name from slack.");
             // if the user is not in the store then we look up the displayname
             const nullGhost = new slackGhost({main: main});
-            var room = main.getRoomBySlackChannelId(message.channel);
+            const room = main.getRoomBySlackChannelId(message.channel);
             display_name = await nullGhost.getDisplayName(id, room.getAccessToken());
             // If the user is not in the room, we cant pills them, we have to just plain text mention them.
             message.text = message.text.replace(USER_ID_REGEX_FIRST, display_name);

--- a/lib/BaseSlackHandler.js
+++ b/lib/BaseSlackHandler.js
@@ -90,12 +90,7 @@ BaseSlackHandler.prototype.replaceUserIdsWithNames = async function(message, tok
         if (users === undefined || !users.length) {
             log.warn("Mentioned user not in store. Looking up display name from slack.");
             // if the user is not in the store then we look up the displayname
-            const nullGhost = new slackGhost({
-                main: main,
-                user_id: null,
-                intent: null,
-                display_name: null,
-                avatar_url: null});
+            const nullGhost = new slackGhost({main: main});
             var room = main.getRoomBySlackChannelId(message.channel);
             display_name = await nullGhost.getDisplayName(id, room.getAccessToken());
             // If the user is not in the room, we cant pills them, we have to just plain text mention them.

--- a/lib/SlackGhost.js
+++ b/lib/SlackGhost.js
@@ -60,17 +60,20 @@ SlackGhost.prototype.update = function(message, room) {
     ]);
 };
 
+SlackGhost.prototype.getDisplayName = function(user_id, access_token) {
+    return this.lookupUserInfo(user_id, access_token).then(user => {
+        if (user && user.profile) {
+            return user.profile.display_name || user.profile.real_name;
+        }
+    });
+}
+
 SlackGhost.prototype.updateDisplayname = function(message, room) {
     var display_name = message.user_name;
 
     var getDisplayName;
     if (!display_name) {
-        getDisplayName = this.lookupUserInfo(message.user_id, room.getAccessToken())
-            .then(user => {
-                if (user && user.profile) {
-                    return user.profile.display_name || user.profile.real_name;
-                }
-            });
+        getDisplayName = this.getDisplayName(message.user_id, room.getAccessToken());
     } else {
         getDisplayName = Promise.resolve(display_name);
     }


### PR DESCRIPTION
This completely refactors `BaseSlackHandler.replaceUserIdsWithNames` to first check the UserStore for the display name and then fallback on querying slack for the display name. This means it should always be consistent with the nick of any user in the matrix room.

Signed off by: Stuart Mumford <stuart@cadair.com>