### PR TITLE
Remove hardcoding JPEG as filetype in thumbnail URIs

### DIFF
--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -344,12 +344,11 @@ BridgedRoom.prototype._handleSlackMessage = function(message, ghost) {
                 let thumbnail_promise = Promise.resolve();
                 // Slack ain't a believer in consistency.
                 const thumb_uri = file.thumb_video || file.thumb_360;
-                if (thumb_uri) {
+                if (thumb_uri && file.filetype) {
                     thumbnail_promise = ghost.uploadContentFromURI(
                         {
-                            // Yes, we hardcode jpeg. Slack always use em.
-                            title: `${file.name}_thumb.jpeg`,
-                            mimetype: "image/jpeg",
+                            title: `${file.name}_thumb.${file.filetype}`,
+                            mimetype: "image/" + file.filetype,
                         },
                         thumb_uri,
                         this._slack_bot_token

--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -348,7 +348,7 @@ BridgedRoom.prototype._handleSlackMessage = function(message, ghost) {
                     thumbnail_promise = ghost.uploadContentFromURI(
                         {
                             title: `${file.name}_thumb.${file.filetype}`,
-                            mimetype: "image/" + file.filetype,
+                            mimetype: file.mimetype,
                         },
                         thumb_uri,
                         this._slack_bot_token


### PR DESCRIPTION
It seems that Slack now _does_ pass on non-JPEGs as thumbnails. I wasn't able to send any file other than `jpeg`s, previously. This quick change removes the hard-coded ".jpeg" extensions from outgoing messages in favor of their reported file-type.