### PR TITLE
Add support for Edits

### DIFF
--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -222,52 +222,51 @@ BridgedRoom.prototype.onMatrixRedaction = async function(message) {
     return await rp(sendMessageParams);
 };
 
-BridgedRoom.prototype.onMatrixMessage = function(message) {
+BridgedRoom.prototype.onMatrixMessage = async function(message) {
     if (!this._slack_webhook_uri && !this._slack_bot_token) return Promise.resolve();
 
-    return this._main.getOrCreateMatrixUser(message.user_id).then((user) => {
-        substitutions.matrixToSlack(message, this._main).then(body => {
-            const uri = (this._slack_bot_token) ? "https://slack.com/api/chat.postMessage" : this._slack_webhook_uri;
+    const user = await this._main.getOrCreateMatrixUser(message.user_id);
+    const body = await substitutions.matrixToSlack(message, this._main);
+    const uri = (this._slack_bot_token) ? "https://slack.com/api/chat.postMessage" : this._slack_webhook_uri;
 
-            const sendMessageParams = {
-                method: "POST",
-                json: true,
-                uri: uri,
-                body: body,
-            };
-            if (this._slack_bot_token) {
-                sendMessageParams.headers = {
-                    Authorization: 'Bearer ' + this._slack_bot_token
-                };
-                // See https://api.slack.com/methods/chat.postMessage#authorship
-                sendMessageParams.body.as_user = false;
-                sendMessageParams.body.channel = this._slack_channel_id;
-            }
+    const sendMessageParams = {
+        method: "POST",
+        json: true,
+        uri: uri,
+        body: body,
+    };
+    if (this._slack_bot_token) {
+        sendMessageParams.headers = {
+            Authorization: 'Bearer ' + this._slack_bot_token
+        };
+        // See https://api.slack.com/methods/chat.postMessage#authorship
+        sendMessageParams.body.as_user = false;
+        sendMessageParams.body.channel = this._slack_channel_id;
+    }
 
-            sendMessageParams.body.username = user.getDisplaynameForRoom(message.room_id);
+    sendMessageParams.body.username = user.getDisplaynameForRoom(message.room_id);
 
-            const avatar_url = user.getAvatarUrlForRoom(message.room_id);
+    const avatar_url = user.getAvatarUrlForRoom(message.room_id);
 
-            if (avatar_url && avatar_url.indexOf("mxc://") === 0) {
-                sendMessageParams.body.icon_url = this._main.getUrlForMxc(avatar_url);
-            }
+    if (avatar_url && avatar_url.indexOf("mxc://") === 0) {
+        sendMessageParams.body.icon_url = this._main.getUrlForMxc(avatar_url);
+    }
 
-            user.bumpATime();
-            this._matrixAtime = Date.now() / 1000;
+    user.bumpATime();
+    this._matrixAtime = Date.now() / 1000;
 
-            return rp(sendMessageParams).then((res) => {
-                this._main.incCounter("sent_messages", {side: "remote"});
-                if (!res || !res.ok) {
-                    log.error("HTTP Error: ", res);
-                }
-                else {
-                    const event = new StoreEvent(message.room_id, message.event_id, this._slack_channel_id, res.ts);
-                    const store = this._main.getEventStore();
-                    store.upsertEvent(event);
-                }
-            });
-        });
-    });
+    const res = await rp(sendMessageParams);
+    this._main.incCounter("sent_messages", {side: "remote"});
+    if (!res || !res.ok) {
+        log.error("HTTP Error: ", res);
+    }
+    else {
+        // Add this event to the event store
+        const event = new StoreEvent(message.room_id, message.event_id, this._slack_channel_id, res.ts);
+        const store = this._main.getEventStore();
+        store.upsertEvent(event);
+    }
+    return res;
 };
 
 BridgedRoom.prototype.onSlackMessage = async function(message) {

--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -280,10 +280,12 @@ BridgedRoom.prototype.onSlackMessage = async function(message) {
     }
 };
 
-BridgedRoom.prototype._handleSlackMessage = function(message, ghost) {
+
+BridgedRoom.prototype._handleSlackMessage = async function(message, ghost) {
     var roomID = this.getMatrixRoomId();
     const eventTS = message.event_ts;
     const slackRoomID = this.getSlackChannelId();
+    const eventStore = this._main.getEventStore();
 
     ghost.bumpATime();
     this._slackAtime = Date.now() / 1000;
@@ -332,11 +334,19 @@ BridgedRoom.prototype._handleSlackMessage = function(message, ghost) {
 
         const formatted = `<i>(edited)</i> ${before} <font color="red"> ${prev} </font> ${after} =&gt; ${before} <font color="green"> ${curr} </font> ${after}`;
 
+        const prev_event = await eventStore.getEntryByRemoteId(slackRoomID, message.previous_message.ts);
         const matrixcontent = {
             body: outtext,
             msgtype: "m.text",
             formatted_body: formatted,
-            format: "org.matrix.custom.html"
+            format: "org.matrix.custom.html",
+            "m.relates_to": {
+                rel_type: "m.replace",
+                event_id: prev_event.eventId},
+            "m.new_content": {
+                msgtype: "m.text",
+                // TODO: Add formatted body here
+                body: new_message}
         };
 
         return ghost.sendMessage(roomID, matrixcontent, slackRoomID, eventTS);

--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -222,6 +222,50 @@ BridgedRoom.prototype.onMatrixRedaction = async function(message) {
     return await rp(sendMessageParams);
 };
 
+BridgedRoom.prototype.onMatrixEdit = async function(message) {
+    if (!this._slack_webhook_uri && !this._slack_bot_token) return Promise.resolve();
+
+    const eventStore = this._main.getEventStore();
+    const event = await eventStore.getEntryByMatrixId(message.room_id, message.content['m.relates_to'].event_id);
+
+    // re-write the message so the matrixToSlack converter works as expected.
+    const new_message = JSON.parse(JSON.stringify(message));
+    new_message.content = message.content['m.new_content'];
+
+    const body = await substitutions.matrixToSlack(new_message, this._main);
+
+    const sendMessageParams = {
+        method: "POST",
+        json: true,
+        uri: "https://slack.com/api/chat.update",
+        body: body,
+    };
+    sendMessageParams.body.ts = event.remoteEventId;
+    sendMessageParams.body.as_user = false;
+    sendMessageParams.body.channel = this._slack_channel_id;
+
+    log.debug(sendMessageParams);
+    if (this._slack_bot_token) {
+        sendMessageParams.headers = {
+            Authorization: 'Bearer ' + this._slack_bot_token
+        };
+        // See https://api.slack.com/methods/chat.postMessage#authorship
+    }
+    const res = await rp(sendMessageParams);
+    this._main.incCounter("sent_messages", {side: "remote"});
+    if (!res || !res.ok) {
+        log.error("HTTP Error: ", res);
+    }
+    else {
+        // Add this event to the event store
+        const event = new StoreEvent(message.room_id, message.event_id, this._slack_channel_id, res.ts);
+        const store = this._main.getEventStore();
+        store.upsertEvent(event);
+    }
+    return res;
+
+};
+
 BridgedRoom.prototype.onMatrixMessage = async function(message) {
     if (!this._slack_webhook_uri && !this._slack_bot_token) return Promise.resolve();
 

--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -191,15 +191,15 @@ BridgedRoom.prototype.toEntry = function() {
 };
 
 BridgedRoom.prototype.onMatrixRedaction = async function(message) {
-    if (!this._slack_bot_token) return Promise.resolve();
+    if (!this._slack_bot_token) return;
 
     const eventStore = this._main.getEventStore();
     const event = await eventStore.getEntryByMatrixId(message.room_id, message.redacts);
 
     // If we don't get an event then exit
     if (event === null) {
-        log.debug("Could not find event to delete.");
-        return Promise.resolve();
+        log.debug("Could not find event '${message.redacts}' in room '${message.room_id}' to delete.");
+        return;
     }
 
     const body = {channel: this._slack_channel_id,
@@ -244,12 +244,10 @@ BridgedRoom.prototype.onMatrixEdit = async function(message) {
     sendMessageParams.body.as_user = false;
     sendMessageParams.body.channel = this._slack_channel_id;
 
-    log.debug(sendMessageParams);
     if (this._slack_bot_token) {
         sendMessageParams.headers = {
             Authorization: 'Bearer ' + this._slack_bot_token
         };
-        // See https://api.slack.com/methods/chat.postMessage#authorship
     }
     const res = await rp(sendMessageParams);
     this._main.incCounter("sent_messages", {side: "remote"});
@@ -284,10 +282,14 @@ BridgedRoom.prototype.onMatrixMessage = async function(message) {
             Authorization: 'Bearer ' + this._slack_bot_token
         };
         // See https://api.slack.com/methods/chat.postMessage#authorship
+        // Setting as_user to false means "When the as_user parameter is set to
+        // false, messages are posted as "bot_messages", with message authorship
+        // attributed to the user name"
         sendMessageParams.body.as_user = false;
         sendMessageParams.body.channel = this._slack_channel_id;
     }
 
+    // Set the username which is used because as_user is false.
     sendMessageParams.body.username = user.getDisplaynameForRoom(message.room_id);
 
     const avatar_url = user.getAvatarUrlForRoom(message.room_id);
@@ -325,7 +327,7 @@ BridgedRoom.prototype.onSlackMessage = async function(message) {
 
 
 BridgedRoom.prototype._handleSlackMessage = async function(message, ghost) {
-    var roomID = this.getMatrixRoomId();
+    const roomID = this.getMatrixRoomId();
     const eventTS = message.event_ts;
     const slackRoomID = this.getSlackChannelId();
     const eventStore = this._main.getEventStore();

--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -321,7 +321,8 @@ BridgedRoom.prototype.onSlackMessage = async function(message) {
         await ghost.update(message, this);
         return await this._handleSlackMessage(message, ghost);
     } catch(err) {
-        log.err("Failed to process event");
+        log.error("Failed to process event");
+        log.error(err);
     }
 };
 

--- a/lib/Main.js
+++ b/lib/Main.js
@@ -543,6 +543,21 @@ Main.prototype.onMatrixEvent = function(ev) {
 
     // Handle a m.room.message event
     if (ev.type === "m.room.message" || ev.content) {
+        if (ev.content['m.relates_to'] !== undefined) {
+            const relates_to = ev.content['m.relates_to'];
+            if (relates_to.rel_type === "m.replace" && relates_to.event_id !== undefined) {
+                log.info("edit in progress");
+                // We have an edit.
+                room.onMatrixEdit(ev).then(
+                    () => endTimer({outcome: "success"}),
+                    (e) => {
+                        log.error("Failed procesing matrix message: ", e);
+                        endTimer({outcome: "fail"});
+                    }
+                );
+                return;
+            }
+        }
         room.onMatrixMessage(ev).then(
             () => endTimer({outcome: "success"}),
             (e) => {

--- a/lib/SlackEventHandler.js
+++ b/lib/SlackEventHandler.js
@@ -169,6 +169,17 @@ SlackEventHandler.prototype.handleMessageEvent = function (params) {
     else if (msg.subtype === "message_changed") {
         msg.user_id = msg.message.user;
         msg.text = msg.message.text;
+
+        // Check if the edit was sent by a bot
+        if (msg.message.bot_id !== undefined) {
+            // Check the edit wasn't sent by us
+            if (msg.message.bot_id === room.getSlackBotId()) {
+                return Promise.resolve();
+            }
+            else {
+                msg.user_id = msg.bot_id;
+            }
+        }
     }
     // We must handle message deleted here because it is not done as the ghost
     // user but as the AS user. (There is no user_id in the message event from

--- a/lib/SlackGhost.js
+++ b/lib/SlackGhost.js
@@ -180,18 +180,16 @@ SlackGhost.prototype.sendText = function(room_id, text, slackRoomID, slackEventT
     return this.sendMessage(room_id, content, slackRoomID, slackEventTS);
 };
 
-SlackGhost.prototype.sendMessage = function(room_id, msg, slackRoomID, slackEventTS) {
-    return this.getIntent().sendMessage(room_id, msg).then((matrixEvent) => {
-        log.debug(msg);
-        this._main.incCounter("sent_messages", {side: "matrix"});
+SlackGhost.prototype.sendMessage = async function(room_id, msg, slackRoomID, slackEventTS) {
+    matrixEevent = await this.getIntent().sendMessage(room_id, msg);
+    this._main.incCounter("sent_messages", {side: "matrix"});
 
-        // Add this event to the eventStore
-        const event = new StoreEvent(room_id, matrixEvent.event_id, slackRoomID, slackEventTS);
-        const store = this._main.getEventStore();
-        store.upsertEvent(event);
+    // Add this event to the eventStore
+    const event = new StoreEvent(room_id, matrixEvent.event_id, slackRoomID, slackEventTS);
+    const store = this._main.getEventStore();
+    store.upsertEvent(event);
 
-        return matrixEvent;
-    });
+    return matrixEvent;
 };
 
 SlackGhost.prototype.uploadContentFromURI = function(file, uri, token) {

--- a/lib/SlackGhost.js
+++ b/lib/SlackGhost.js
@@ -181,7 +181,7 @@ SlackGhost.prototype.sendText = function(room_id, text, slackRoomID, slackEventT
 };
 
 SlackGhost.prototype.sendMessage = async function(room_id, msg, slackRoomID, slackEventTS) {
-    matrixEevent = await this.getIntent().sendMessage(room_id, msg);
+    const matrixEvent = await this.getIntent().sendMessage(room_id, msg);
     this._main.incCounter("sent_messages", {side: "matrix"});
 
     // Add this event to the eventStore


### PR DESCRIPTION
This adds support for the edits in riot develop bidirectionally with slack.

Slack -> Matrix edits still display the rich fallback to clients which don't speak the new edits.

builds on #129 


Signed Off By Stuart Mumford (stuart@cadair.com)