### PR TITLE
Replace channel mentions with canonical aliases for bridged rooms

### DIFF
--- a/lib/BaseSlackHandler.js
+++ b/lib/BaseSlackHandler.js
@@ -37,10 +37,8 @@ BaseSlackHandler.prototype.replaceChannelIdsWithNames = async function(message, 
     if (testForName && testForName.length) {
         matches = testForName.length;
     }
-    return promiseWhile(function () {
-        // Do this until there are no more channel ID matches
-        return iteration < matches;
-    }, function () {
+
+    while (iteration < matches) {
         // foreach channelId, pull out the ID
         // (if this is an emote msg, the format is <#ID|name>, but in normal msgs it's just <#ID>
         var id = testForName[iteration].match(CHANNEL_ID_REGEX_FIRST)[1];
@@ -53,7 +51,8 @@ BaseSlackHandler.prototype.replaceChannelIdsWithNames = async function(message, 
             json: true
         };
         main.incRemoteCallCounter("channels.info");
-        return rp(channelsInfoApiParams).then((response) => {
+        try {
+            const response = await rp(channelsInfoApiParams);
             let name = id;
             if (response && response.channel && response.channel.name) {
                 log.info("channels.info: " + id + " mapped to " + response.channel.name);
@@ -64,15 +63,12 @@ BaseSlackHandler.prototype.replaceChannelIdsWithNames = async function(message, 
             }
             message.text = message.text.replace(CHANNEL_ID_REGEX_FIRST, "#" + name);
             iteration++;
-            }).catch((err) => {
-               log.error("Caught error handling channels.info:" + err);
-            });
-    }).then(() => {
-        // Notice we can chain it because it's a Promise,
-        // this will run after completion of the promiseWhile Promise!
-        return message;
-    });
-};
+        } catch(err) {
+            log.error("Caught error handling channels.info:" + err);
+        }
+    }
+    return message;
+    };
 
 BaseSlackHandler.prototype.replaceUserIdsWithNames = async function(message, token) {
     if (message.text === undefined) {

--- a/lib/BaseSlackHandler.js
+++ b/lib/BaseSlackHandler.js
@@ -23,6 +23,33 @@ function BaseSlackHandler(main) {
     this._main = main;
 }
 
+BaseSlackHandler.prototype.getSlackRoomNameFromID = async function(id, token) {
+    var main = this._main;
+    var channelsInfoApiParams = {
+        uri: 'https://slack.com/api/channels.info',
+        qs: {
+            token: token,
+            channel: id
+        },
+        json: true
+    };
+    main.incRemoteCallCounter("channels.info");
+    let name = id;
+    try {
+        const response = await rp(channelsInfoApiParams);
+        if (response && response.channel && response.channel.name) {
+            log.info("channels.info: " + id + " mapped to " + response.channel.name);
+            name = response.channel.name;
+        }
+        else {
+            log.info("channels.info returned no result for " + id);
+        }
+    } catch(err) {
+        log.error("Caught error handling channels.info:" + err);
+    }
+    return name;
+};
+
 BaseSlackHandler.prototype.replaceChannelIdsWithNames = async function(message, token) {
     var main = this._main;
 
@@ -42,33 +69,31 @@ BaseSlackHandler.prototype.replaceChannelIdsWithNames = async function(message, 
         // foreach channelId, pull out the ID
         // (if this is an emote msg, the format is <#ID|name>, but in normal msgs it's just <#ID>
         var id = testForName[iteration].match(CHANNEL_ID_REGEX_FIRST)[1];
-        var channelsInfoApiParams = {
-            uri: 'https://slack.com/api/channels.info',
-            qs: {
-                token: token,
-                channel: id
-            },
-            json: true
-        };
-        main.incRemoteCallCounter("channels.info");
-        try {
-            const response = await rp(channelsInfoApiParams);
-            let name = id;
-            if (response && response.channel && response.channel.name) {
-                log.info("channels.info: " + id + " mapped to " + response.channel.name);
-                name = response.channel.name;
+
+        // Lookup the room in the store.
+        var room = main.getRoomBySlackChannelId(id);
+
+        // If we bridge the room, attempt to look up its canonical alias.
+        if (room !== undefined) {
+            const client = this._main.getBotIntent().getClient();
+            const canonical = await client.getStateEvent(room._matrix_room_id, "m.room.canonical_alias");
+            if (canonical !== undefined && canonical.alias !== undefined) {
+                message.text = message.text.replace(CHANNEL_ID_REGEX_FIRST, canonical.alias);
+            } else {
+            // If we can't find a canonical alias fall back to just the slack channel name.
+            room = undefined;
             }
-            else {
-                log.info("channels.info returned no result for " + id);
-            }
-            message.text = message.text.replace(CHANNEL_ID_REGEX_FIRST, "#" + name);
-            iteration++;
-        } catch(err) {
-            log.error("Caught error handling channels.info:" + err);
         }
+
+        // If we can't match the room then we just put the slack name
+        if (room === undefined) {
+            const name = await this.getSlackRoomNameFromID(id, token);
+            message.text = message.text.replace(CHANNEL_ID_REGEX_FIRST, "#" + name);
+        }
+        iteration++;
     }
     return message;
-    };
+};
 
 BaseSlackHandler.prototype.replaceUserIdsWithNames = async function(message, token) {
     if (message.text === undefined) {

--- a/lib/BaseSlackHandler.js
+++ b/lib/BaseSlackHandler.js
@@ -40,7 +40,7 @@ BaseSlackHandler.prototype.getSlackRoomNameFromID = async function(id, token) {
             log.info("channels.info: " + id + " mapped to " + response.channel.name);
             return response.channel.name;
         }
-        else log.info("channels.info returned no result for " + id);
+        log.info("channels.info returned no result for " + id);
 
     } catch(err) {
         log.error("Caught error handling channels.info:" + err);

--- a/lib/BaseSlackHandler.js
+++ b/lib/BaseSlackHandler.js
@@ -24,8 +24,8 @@ function BaseSlackHandler(main) {
 }
 
 BaseSlackHandler.prototype.getSlackRoomNameFromID = async function(id, token) {
-    var main = this._main;
-    var channelsInfoApiParams = {
+    const main = this._main;
+    const channelsInfoApiParams = {
         uri: 'https://slack.com/api/channels.info',
         qs: {
             token: token,
@@ -34,20 +34,18 @@ BaseSlackHandler.prototype.getSlackRoomNameFromID = async function(id, token) {
         json: true
     };
     main.incRemoteCallCounter("channels.info");
-    let name = id;
     try {
         const response = await rp(channelsInfoApiParams);
         if (response && response.channel && response.channel.name) {
             log.info("channels.info: " + id + " mapped to " + response.channel.name);
-            name = response.channel.name;
+            return response.channel.name;
         }
-        else {
-            log.info("channels.info returned no result for " + id);
-        }
+        else log.info("channels.info returned no result for " + id);
+
     } catch(err) {
         log.error("Caught error handling channels.info:" + err);
     }
-    return name;
+    return id;
 };
 
 BaseSlackHandler.prototype.replaceChannelIdsWithNames = async function(message, token) {
@@ -68,10 +66,10 @@ BaseSlackHandler.prototype.replaceChannelIdsWithNames = async function(message, 
     while (iteration < matches) {
         // foreach channelId, pull out the ID
         // (if this is an emote msg, the format is <#ID|name>, but in normal msgs it's just <#ID>
-        var id = testForName[iteration].match(CHANNEL_ID_REGEX_FIRST)[1];
+        const id = testForName[iteration].match(CHANNEL_ID_REGEX_FIRST)[1];
 
         // Lookup the room in the store.
-        var room = main.getRoomBySlackChannelId(id);
+        const room = main.getRoomBySlackChannelId(id);
 
         // If we bridge the room, attempt to look up its canonical alias.
         if (room !== undefined) {
@@ -80,8 +78,8 @@ BaseSlackHandler.prototype.replaceChannelIdsWithNames = async function(message, 
             if (canonical !== undefined && canonical.alias !== undefined) {
                 message.text = message.text.replace(CHANNEL_ID_REGEX_FIRST, canonical.alias);
             } else {
-            // If we can't find a canonical alias fall back to just the slack channel name.
-            room = undefined;
+                // If we can't find a canonical alias fall back to just the slack channel name.
+                room = undefined;
             }
         }
 

--- a/lib/Main.js
+++ b/lib/Main.js
@@ -121,7 +121,7 @@ Main.prototype.initialiseMetrics = function() {
 
             matrixUsersByAge: count_ages(this._matrixUsersById),
             remoteUsersByAge: count_ages(this._ghostsByUserId),
-        }
+        };
     });
 
     metrics.addCounter({
@@ -172,11 +172,11 @@ Main.prototype.getOAuth2 = function() {
 };
 
 Main.prototype.getEventStore = function() {
-    return this._bridge.getEventStore()
+    return this._bridge.getEventStore();
 };
 
 Main.prototype.getRoomStore = function() {
-    return this._bridge.getRoomStore()
+    return this._bridge.getRoomStore();
 };
 
 Main.prototype.putRoomToStore = function(room) {

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -111,7 +111,7 @@ var getSlackFileUrl = function(file) {
  * @param {Main} main the toplevel main instance
  * @return An object which can be posted as JSON to the Slack API.
  */
-var matrixToSlack = async function(event, main) {
+const matrixToSlack = async function(event, main) {
     log.debug("Event from matrix: " + JSON.stringify(event));
 
     var string = event.content.body;

--- a/lib/substitutions.js
+++ b/lib/substitutions.js
@@ -74,6 +74,7 @@ var slackToMatrix = function(body, file) {
 
     // convert @channel to @room
     body = body.replace("<!channel>", "@room");
+    body = body.replace("<!here>", "@room");
 
     // if we have a file, attempt to get the direct link to the file
     if (file && file.public_url_shared) {
@@ -110,7 +111,7 @@ var getSlackFileUrl = function(file) {
  * @param {Main} main the toplevel main instance
  * @return An object which can be posted as JSON to the Slack API.
  */
-var matrixToSlack = function(event, main) {
+var matrixToSlack = async function(event, main) {
     log.debug("Event from matrix: " + JSON.stringify(event));
 
     var string = event.content.body;
@@ -141,6 +142,25 @@ var matrixToSlack = function(event, main) {
                 const userid = match[1].split("_")[1].split(":")[0];
                 // Construct the new slack mention
                 string = string.replace(match[2], "<@" + userid + ">");
+                match = regex.exec(html_string);
+            }
+        }
+
+        // replace riot "pill" behavior for room links
+        if (undefined != html_string) {
+            const regex = new RegExp('<a href="https://matrix.to/#/#' +
+                                     '([^"]+)">([^<]+)</a>', "g");
+
+            let match = regex.exec(html_string);
+            while (match != null) {
+                const alias = match[2];
+                const client = main.getBotIntent().getClient();
+                const room_id = await client.getRoomIdForAlias(alias);
+                const room = main.getRoomByMatrixRoomId(room_id['room_id']);
+                if (room !== undefined) {
+                    const slack_channel_id = room.getSlackChannelId();
+                    string = string.replace(alias, "<#" + slack_channel_id + ">");
+                }
                 match = regex.exec(html_string);
             }
         }


### PR DESCRIPTION
This looks up rooms we bridge in the room store and then attempts to get the canonical alias for a room out of room state and replaces that in the plain text of the slack message. As much as I would like to handle proper pills replacement etc that will have to wait until we have refactored the subs.

Now with a bonus 4th commit that takes room pills from Riot and transforms them back into slack channel links.

Signed Off By: Stuart Mumford (stuart@cadair.com)