### PR TITLE
teams.db path should use dbdir

### DIFF
--- a/lib/Main.js
+++ b/lib/Main.js
@@ -734,10 +734,11 @@ Main.prototype.actionUnlink = function(opts) {
 Main.prototype.run = function(port) {
     var bridge = this._bridge;
     var config = this._config;
+    const dbdir = config.dbdir || "";
 
     bridge.loadDatabases().then(() => {
         log.info("Loading teams.db");
-        this._teamDatastore = new Datastore({ filename: './teams.db', autoload: true });
+        this._teamDatastore = new Datastore({ filename: path.join(dbdir, "teams.db"), autoload: true });
         return new Promise((resolve, reject) => {
             this._teamDatastore.loadDatabase((err) => {
             if (err) {


### PR DESCRIPTION
The bot won't accept the room invite if current working dir is not writable (e.g. in k8s environment). In this case `dbdir` has to be set.

This PR ensures the bridge won't crash when `dbdir` is set, as previously only local `teams.db` path was used

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>