### PR TITLE
Use Slack's library for calling HTTP endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,49 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@slack/logger": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-1.0.0.tgz",
+      "integrity": "sha512-QDYhQR/58xKfB5iquvQwfpxPsmKPP/5SuDp8hRhZeUluCHsP1qBCOc3sW2Xb3cydxK0PAEnkLbBJf/ezsGwtlA==",
+      "requires": {
+        "@types/node": ">=8.9.0"
+      }
+    },
+    "@slack/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-uak4Jbi8nlX8xmElkPt1ixxVQXMKdBRbzBayn5bRzZ9Yx3bQGlyJdFs6GjEKI+fvFP0ZTiGWKOzlJTH3Tm/9fg=="
+    },
+    "@slack/web-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-5.1.0.tgz",
+      "integrity": "sha512-bnzS1I8iOfNB4xSX0zQ/uRBnWTy7iPnAd0y+H/D8YRbEiXqAWaxlVQB8pio54hegSVcRRWRKFb2fyViSraMXqw==",
+      "requires": {
+        "@slack/logger": "^1.0.0",
+        "@slack/types": "^1.1.0",
+        "@types/is-stream": "^1.1.0",
+        "@types/node": ">=8.9.0",
+        "@types/p-queue": "^2.3.2",
+        "axios": "^0.18.0",
+        "eventemitter3": "^3.1.0",
+        "form-data": "^2.5.0",
+        "is-stream": "^1.1.0",
+        "p-queue": "^2.4.2",
+        "p-retry": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.0.tgz",
+          "integrity": "sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/body-parser": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
@@ -85,6 +128,14 @@
         "@types/node": "*"
       }
     },
+    "@types/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
@@ -109,14 +160,18 @@
     "@types/node": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz",
-      "integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==",
-      "dev": true
+      "integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ=="
     },
     "@types/node-emoji": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@types/node-emoji/-/node-emoji-1.8.1.tgz",
       "integrity": "sha512-0fRfA90FWm6KJfw6P9QGyo0HDTCmthZ7cWaBQndITlaWLTZ6njRyKwrwpzpg+n6kBXBIGKeUHEQuBx7bphGJkA==",
       "dev": true
+    },
+    "@types/p-queue": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/p-queue/-/p-queue-2.3.2.tgz",
+      "integrity": "sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ=="
     },
     "@types/randomstring": {
       "version": "1.1.6",
@@ -150,6 +205,11 @@
       "requires": {
         "@types/request": "*"
       }
+    },
+    "@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
     },
     "@types/serve-static": {
       "version": "1.13.2",
@@ -191,20 +251,6 @@
       "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
       "dev": true
     },
-    "Base64": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-      "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg="
-    },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      }
-    },
     "Slackdown": {
       "version": "github:Half-Shot/slackdown#efd8934a3d9c3bf0064c0b217c5cf6b62ee697e4",
       "from": "github:Half-Shot/slackdown#efd8934a3d9c3bf0064c0b217c5cf6b62ee697e4"
@@ -223,39 +269,6 @@
         "negotiator": "0.6.2"
       }
     },
-    "acorn": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-    },
-    "acorn-dynamic-import": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
-    },
-    "acorn-node": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.7.0.tgz",
-      "integrity": "sha512-XhahLSsCB6X6CJbe+uNu3Mn9sJBNFxtBN9NLgAOQovfS6Kh0lDUtmlclhjn9CvEK7A7YyRU13PXlNcpSiLI9Yw==",
-      "requires": {
-        "acorn": "^6.1.1",
-        "acorn-dynamic-import": "^4.0.0",
-        "acorn-walk": "^6.1.1",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
-          "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw=="
-        }
-      }
-    },
-    "acorn-walk": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-      "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
-    },
     "ajv": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
@@ -266,11 +279,6 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "another-json": {
       "version": "0.2.0",
@@ -328,39 +336,6 @@
         "safer-buffer": "~2.1.0"
       }
     },
-    "asn1.js": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-      "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "assert": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
-      "integrity": "sha1-A5OaYiWCqBLMICMgoLmlbJuBWEk=",
-      "requires": {
-        "util": "0.10.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        },
-        "util": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-          "requires": {
-            "inherits": "2.0.1"
-          }
-        }
-      }
-    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -370,14 +345,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
-    },
-    "astw": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
-      "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
-      "requires": {
-        "acorn": "^4.0.3"
-      }
     },
     "async": {
       "version": "0.2.10",
@@ -399,6 +366,22 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axios": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        }
+      }
+    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -411,7 +394,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base-x": {
       "version": "3.0.6",
@@ -420,11 +404,6 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
-    },
-    "base64-js": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-      "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -455,11 +434,6 @@
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
       "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
-    "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -481,26 +455,10 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
-    },
-    "browser-pack": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
-      "integrity": "sha1-QZdxmyDG4KqglFHFER5T77b7wY0=",
-      "requires": {
-        "JSONStream": "^1.0.3",
-        "combine-source-map": "~0.6.1",
-        "defined": "^1.0.0",
-        "through2": "^1.0.0",
-        "umd": "^3.0.0"
       }
     },
     "browser-request": {
@@ -508,175 +466,11 @@
       "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
       "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
     },
-    "browser-resolve": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-      "requires": {
-        "resolve": "1.1.7"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
-        }
-      }
-    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
-    },
-    "browserify": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-10.2.6.tgz",
-      "integrity": "sha1-3L/veU9Uj1+EmCFIFPaXpcUMCJY=",
-      "requires": {
-        "JSONStream": "^1.0.3",
-        "assert": "~1.3.0",
-        "browser-pack": "^5.0.0",
-        "browser-resolve": "^1.7.1",
-        "browserify-zlib": "~0.1.2",
-        "buffer": "^3.0.0",
-        "builtins": "~0.0.3",
-        "commondir": "0.0.1",
-        "concat-stream": "~1.4.1",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "~0.0.1",
-        "crypto-browserify": "^3.0.0",
-        "defined": "^1.0.0",
-        "deps-sort": "^1.3.7",
-        "domain-browser": "~1.1.0",
-        "duplexer2": "~0.0.2",
-        "events": "~1.0.0",
-        "glob": "^4.0.5",
-        "has": "^1.0.0",
-        "htmlescape": "^1.1.0",
-        "http-browserify": "^1.4.0",
-        "https-browserify": "~0.0.0",
-        "inherits": "~2.0.1",
-        "insert-module-globals": "^6.4.1",
-        "isarray": "0.0.1",
-        "labeled-stream-splicer": "^1.0.0",
-        "module-deps": "^3.7.11",
-        "os-browserify": "~0.1.1",
-        "parents": "^1.0.1",
-        "path-browserify": "~0.0.0",
-        "process": "~0.11.0",
-        "punycode": "^1.3.2",
-        "querystring-es3": "~0.2.0",
-        "read-only-stream": "^1.1.1",
-        "readable-stream": "^1.1.13",
-        "resolve": "^1.1.4",
-        "shasum": "^1.0.0",
-        "shell-quote": "~0.0.1",
-        "stream-browserify": "^1.0.0",
-        "string_decoder": "~0.10.0",
-        "subarg": "^1.0.0",
-        "syntax-error": "^1.1.1",
-        "through2": "^1.0.0",
-        "timers-browserify": "^1.0.1",
-        "tty-browserify": "~0.0.0",
-        "url": "~0.10.1",
-        "util": "~0.10.1",
-        "vm-browserify": "~0.0.1",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
-    "browserify-aes": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-      "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "browserify-cipher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-      "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
-      }
-    },
-    "browserify-des": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-      "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "browserify-rsa": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-      "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
-      }
-    },
-    "browserify-sign": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-      "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
-      }
-    },
-    "browserify-zlib": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-      "requires": {
-        "pako": "~0.2.0"
-      }
     },
     "bs58": {
       "version": "4.0.1",
@@ -686,37 +480,17 @@
         "base-x": "^3.0.2"
       }
     },
-    "buffer": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
-      "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
-      "requires": {
-        "base64-js": "0.0.8",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
-      }
-    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "buffer-xor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
-    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
-    },
-    "builtins": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
-      "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo="
     },
     "bytes": {
       "version": "3.1.0",
@@ -760,15 +534,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
-    },
-    "cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
     },
     "cliui": {
       "version": "5.0.0",
@@ -836,17 +601,6 @@
         "text-hex": "1.0.x"
       }
     },
-    "combine-source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
-      "integrity": "sha1-m0oJwxYDPXaODxHgKfonMOB5rZY=",
-      "requires": {
-        "convert-source-map": "~1.1.0",
-        "inline-source-map": "~0.5.0",
-        "lodash.memoize": "~3.0.3",
-        "source-map": "~0.4.2"
-      }
-    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -861,61 +615,11 @@
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
       "dev": true
     },
-    "commondir": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
-      "integrity": "sha1-ifAP3NUbUZxXhzP+xWPmptp/W+I="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "concat-stream": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.11.tgz",
-      "integrity": "sha512-X3JMh8+4je3U1cQpG87+f9lXHDrqcb2MVLg9L7o8b1UZ0DzhRrUpdn65ttzu10PpJPPI3MQNkis+oha6TSA9Mw==",
-      "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "~1.1.9",
-        "typedarray": "~0.0.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
-    "console-browserify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "requires": {
-        "date-now": "^0.1.4"
-      }
-    },
-    "constants-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
-      "integrity": "sha1-kld9tSe6bEzwpFaNhLwDH0QeIfI="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -929,11 +633,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-    },
-    "convert-source-map": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
-      "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
     },
     "cookie": {
       "version": "0.4.0",
@@ -955,40 +654,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "create-ecdh": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
-      "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
-      }
-    },
-    "create-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
-      }
-    },
-    "create-hmac": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -999,24 +664,6 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
-      }
-    },
-    "crypto-browserify": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-      "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
       }
     },
     "cycle": {
@@ -1031,11 +678,6 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
-    },
-    "date-now": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
     },
     "debug": {
       "version": "2.6.9",
@@ -1067,11 +709,6 @@
         "object-keys": "^1.0.12"
       }
     },
-    "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1082,46 +719,10 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
-    "deps-sort": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
-      "integrity": "sha1-Kd//U+F7Nq7K51MK27v2IsLtGnE=",
-      "requires": {
-        "JSONStream": "^1.0.3",
-        "shasum": "^1.0.0",
-        "subarg": "^1.0.0",
-        "through2": "^1.0.0"
-      }
-    },
-    "des.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
-      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-      "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
-    "detective": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
-      "requires": {
-        "acorn": "^5.2.1",
-        "defined": "^1.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
-        }
-      }
     },
     "diagnostics": {
       "version": "1.1.1",
@@ -1139,52 +740,6 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
-    "diffie-hellman": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-      "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
-      }
-    },
-    "domain-browser": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-      "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
-    },
-    "duplexer2": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "requires": {
-        "readable-stream": "~1.1.9"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1198,20 +753,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-    },
-    "elliptic": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
-      "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
-      "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
-      }
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -1295,19 +836,10 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
-    "events": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
-      "integrity": "sha1-dYSdz+k9EPsFfDAFWv29UdBqjiQ="
-    },
-    "evp_bytestokey": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
-      }
+    "eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "execa": {
       "version": "1.0.0",
@@ -1437,6 +969,24 @@
         }
       }
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -1471,7 +1021,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "generate-function": {
       "version": "2.3.1",
@@ -1515,17 +1066,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "glob": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-      "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-      "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^2.0.1",
-        "once": "^1.3.0"
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -1544,6 +1084,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -1559,53 +1100,11 @@
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
-    "hash-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
-    },
-    "hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "htmlescape": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
-      "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
-    },
-    "http-browserify": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
-      "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
-      "requires": {
-        "Base64": "~0.2.0",
-        "inherits": "~2.0.1"
-      }
     },
     "http-errors": {
       "version": "1.7.2",
@@ -1629,11 +1128,6 @@
         "sshpk": "^1.7.0"
       }
     },
-    "https-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-      "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1642,25 +1136,16 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-    },
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1670,29 +1155,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "inline-source-map": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
-      "integrity": "sha1-Skxd2OT7Xps82mDIIt+tyu5m4K8=",
-      "requires": {
-        "source-map": "~0.4.0"
-      }
-    },
-    "insert-module-globals": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
-      "integrity": "sha1-IGOOKaMPntHKLjqCX7wsulJG3fw=",
-      "requires": {
-        "JSONStream": "^1.0.3",
-        "combine-source-map": "~0.6.1",
-        "concat-stream": "~1.4.1",
-        "is-buffer": "^1.1.0",
-        "lexical-scope": "^1.2.0",
-        "process": "~0.11.0",
-        "through2": "^1.0.0",
-        "xtend": "^4.0.0"
-      }
     },
     "invert-kv": {
       "version": "2.0.0",
@@ -1708,11 +1170,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.1.4",
@@ -1826,28 +1283,10 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
-    "json-stable-stringify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
-      "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-    },
-    "jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "jsonpointer": {
       "version": "4.0.1",
@@ -1873,37 +1312,12 @@
         "colornames": "^1.1.1"
       }
     },
-    "labeled-stream-splicer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
-      "integrity": "sha1-RhUzFTd4SYHo/SZOHzpDTE4N3WU=",
-      "requires": {
-        "inherits": "^2.0.1",
-        "isarray": "~0.0.1",
-        "stream-splicer": "^1.1.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        }
-      }
-    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "requires": {
         "invert-kv": "^2.0.0"
-      }
-    },
-    "lexical-scope": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
-      "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
-      "requires": {
-        "astw": "^2.0.0"
       }
     },
     "lie": {
@@ -1935,11 +1349,6 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-    },
-    "lodash.memoize": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
-      "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
     },
     "lodash.toarray": {
       "version": "4.4.0",
@@ -2056,28 +1465,6 @@
         }
       }
     },
-    "matrix-js-sdk": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-0.5.6.tgz",
-      "integrity": "sha1-TLTgHFB6Sge1dTKNBZcLZdQnw3s=",
-      "requires": {
-        "another-json": "^0.2.0",
-        "browser-request": "^0.3.3",
-        "browserify": "^10.2.3",
-        "q": "^1.4.1",
-        "request": "^2.53.0"
-      }
-    },
-    "md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -2103,15 +1490,6 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
-    "miller-rabin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-      "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
-      }
-    },
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -2134,24 +1512,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-    },
-    "minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-    },
-    "minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
-    },
-    "minimatch": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-      "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-      "requires": {
-        "brace-expansion": "^1.0.0"
-      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -2373,50 +1733,6 @@
         }
       }
     },
-    "module-deps": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
-      "integrity": "sha1-6nXK+RmQkNJbDVUStaysuW5/h/M=",
-      "requires": {
-        "JSONStream": "^1.0.3",
-        "browser-resolve": "^1.7.0",
-        "concat-stream": "~1.4.5",
-        "defined": "^1.0.0",
-        "detective": "^4.0.0",
-        "duplexer2": "0.0.2",
-        "inherits": "^2.0.1",
-        "parents": "^1.0.0",
-        "readable-stream": "^1.1.13",
-        "resolve": "^1.1.3",
-        "stream-combiner2": "~1.0.0",
-        "subarg": "^1.0.0",
-        "through2": "^1.0.0",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
@@ -2565,11 +1881,6 @@
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
       "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
     },
-    "os-browserify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
-      "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ="
-    },
     "os-locale": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
@@ -2611,46 +1922,29 @@
         "p-limit": "^2.0.0"
       }
     },
+    "p-queue": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
+      "integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng=="
+    },
+    "p-retry": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.1.0.tgz",
+      "integrity": "sha512-oepllyG9gX1qH4Sm20YAKxg1GA7L7puhvGnTfimi31P07zSIj7SDV6YtuAx9nbJF51DES+2CIIRkXs8GKqWJxA==",
+      "requires": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
+      }
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
-    "pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
-    },
-    "parents": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
-      "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
-      "requires": {
-        "path-platform": "~0.11.15"
-      }
-    },
-    "parse-asn1": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
-      "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
-      "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3",
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-    },
-    "path-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
     },
     "path-exists": {
       "version": "3.0.0",
@@ -2671,12 +1965,8 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-    },
-    "path-platform": {
-      "version": "0.11.15",
-      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
-      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I="
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -2688,27 +1978,10 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
-    "pbkdf2": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
-      "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -2737,19 +2010,6 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz",
       "integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw=="
     },
-    "public-encrypt": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-      "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -2764,42 +2024,10 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-    },
     "qs": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
-    "querystring-es3": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
-    },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "randomfill": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-      "requires": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
-      }
     },
     "randomstring": {
       "version": "1.1.5",
@@ -2825,38 +2053,6 @@
         "unpipe": "1.0.0"
       }
     },
-    "read-only-stream": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
-      "integrity": "sha1-Xad8eZ7ROI0++IoYRxu1kk+KC6E=",
-      "requires": {
-        "readable-stream": "^1.0.31",
-        "readable-wrap": "^1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "readable-stream": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
@@ -2865,37 +2061,6 @@
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
-      }
-    },
-    "readable-wrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
-      "integrity": "sha1-O1ohHGMeEjA6VJkcgGwX564ga/8=",
-      "requires": {
-        "readable-stream": "^1.1.13-1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
       }
     },
     "regenerator-runtime": {
@@ -2969,18 +2134,15 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
       "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
     },
-    "ripemd160": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
-      }
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -3045,24 +2207,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
-    "sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "shasum": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
-      "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
-      "requires": {
-        "json-stable-stringify": "~0.0.0",
-        "sha.js": "~2.4.4"
-      }
-    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -3076,11 +2220,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
-    "shell-quote": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
-      "integrity": "sha1-GkEZbzwDM8SCMjWT1ohuzxU92YY="
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -3092,14 +2231,6 @@
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
         "is-arrayish": "^0.3.1"
-      }
-    },
-    "source-map": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-      "requires": {
-        "amdefine": ">=0.0.4"
       }
     },
     "source-map-support": {
@@ -3156,120 +2287,6 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
-    "stream-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-      "integrity": "sha1-v5tKv7QrJ011FHnkTg/yZWtvEZM=",
-      "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^1.0.27-1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
-    "stream-combiner2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
-      "integrity": "sha1-unKmtQy/q/qVD8i8h2BL0B62BnE=",
-      "requires": {
-        "duplexer2": "~0.0.2",
-        "through2": "~0.5.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "through2": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-          "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-          "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~3.0.0"
-          }
-        },
-        "xtend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-        }
-      }
-    },
-    "stream-splicer": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
-      "integrity": "sha1-PARBvhW5v04iYnXm3IOWR0VUZmE=",
-      "requires": {
-        "indexof": "0.0.1",
-        "inherits": "^2.0.1",
-        "isarray": "~0.0.1",
-        "readable-stream": "^1.1.13-1",
-        "readable-wrap": "^1.0.0",
-        "through2": "^1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "string-width": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -3307,28 +2324,12 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
-    "subarg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
-      "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
-      "requires": {
-        "minimist": "^1.1.0"
-      }
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
-      }
-    },
-    "syntax-error": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
-      "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
-      "requires": {
-        "acorn-node": "^1.2.0"
       }
     },
     "tdigest": {
@@ -3343,51 +2344,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-    },
-    "through2": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
-      "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
-      "requires": {
-        "readable-stream": ">=1.1.13-1 <1.2.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
-    "timers-browserify": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-      "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
-      "requires": {
-        "process": "~0.11.0"
-      }
     },
     "toidentifier": {
       "version": "1.0.0",
@@ -3497,11 +2453,6 @@
         "tslib": "^1.8.1"
       }
     },
-    "tty-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
-      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
-    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -3529,21 +2480,11 @@
         "mime-types": "~2.1.24"
       }
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
     "typescript": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
       "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
       "dev": true
-    },
-    "umd": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
-      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow=="
     },
     "underscore": {
       "version": "1.4.4",
@@ -3566,30 +2507,6 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-        }
-      }
-    },
-    "util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "requires": {
-        "inherits": "2.0.3"
       }
     },
     "util-deprecate": {
@@ -3620,14 +2537,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      }
-    },
-    "vm-browserify": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "requires": {
-        "indexof": "0.0.1"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/matrix-org/matrix-appservice-slack#readme",
   "dependencies": {
+    "@slack/web-api": "^5.1.0",
     "Slackdown": "Half-Shot/slackdown#efd8934a3d9c3bf0064c0b217c5cf6b62ee697e4",
     "chai": "^4.2.0",
     "chalk": "^2.4.1",

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -19,6 +19,8 @@ import * as rp from "request-promise-native";
 import { Main } from "./Main";
 import { SlackGhost } from "./SlackGhost";
 import { default as subs } from "./substitutions";
+import { WebClient } from "@slack/web-api";
+import { FilesSharedPublicURLResponse, ConversationsInfoResponse } from "./SlackResponses";
 
 const log = Logging.get("BaseSlackHandler");
 
@@ -107,38 +109,29 @@ export interface ISlackFile {
 export abstract class BaseSlackHandler {
     constructor(protected main: Main) { }
 
-    public async getSlackRoomNameFromID(id: string, token: string) {
-        const channelsInfoApiParams = {
-            json: true,
-            qs: {
-                channel: id,
-                token,
-            },
-            uri: "https://slack.com/api/conversations.info",
-        };
-        this.main.incRemoteCallCounter("conversations.info");
+    public async getSlackRoomNameFromID(channel: string, client: WebClient) {
         try {
-            const response = await rp(channelsInfoApiParams);
+            const response = (await client.conversations.info({ channel })) as ConversationsInfoResponse;
             if (response && response.channel && response.channel.name) {
-                log.info(`conversations.info: ${id} mapped to ${response.channel.name}`);
+                log.info(`conversations.info: ${channel} mapped to ${response.channel.name}`);
                 return response.channel.name;
             }
-            log.info("conversations.info returned no result for " + id);
+            log.info("conversations.info returned no result for " + channel);
         } catch (err) {
             log.error("Caught error handling conversations.info:" + err);
         }
-        return id;
+        return channel;
     }
 
-    public async doChannelUserReplacements(msg: ISlackMessage, text: string|undefined, token: string) {
+    public async doChannelUserReplacements(msg: ISlackMessage, text: string|undefined, webClient: WebClient) {
         if (text === undefined) {
             return;
         }
-        text = await this.replaceChannelIdsWithNames(msg, text, token);
-        return await this.replaceUserIdsWithNames(msg, text, token);
+        text = await this.replaceChannelIdsWithNames(msg, text, webClient);
+        return await this.replaceUserIdsWithNames(msg, text);
     }
 
-    public async replaceChannelIdsWithNames(message: ISlackMessage, text: string, token: string) {
+    public async replaceChannelIdsWithNames(message: ISlackMessage, text: string, client: WebClient) {
         const testForName = text.match(CHANNEL_ID_REGEX);
         let iteration = 0;
         let matches = 0;
@@ -169,7 +162,7 @@ export abstract class BaseSlackHandler {
 
             // If we can't match the room then we just put the slack name
             if (room === undefined) {
-                const name = await this.getSlackRoomNameFromID(id, token);
+                const name = await this.getSlackRoomNameFromID(id, client);
                 text = text.replace(CHANNEL_ID_REGEX_FIRST, "#" + name);
             }
             iteration++;
@@ -177,7 +170,7 @@ export abstract class BaseSlackHandler {
         return text;
     }
 
-    public async replaceUserIdsWithNames(message: ISlackMessage, text: string, token: string) {
+    public async replaceUserIdsWithNames(message: ISlackMessage, text: string) {
         let match = USER_ID_REGEX.exec(text);
         while (match !== null && match[0]) {
             // foreach userId, pull out the ID
@@ -221,19 +214,10 @@ export abstract class BaseSlackHandler {
      * @return {Promise<Object>} A Promise of the updated slack file data object
      * @throws if the slack request fails or the response didn't contain `file.permalink_public`
      */
-    public async enablePublicSharing(file: ISlackFile, token: string): Promise<ISlackFile> {
+    public async enablePublicSharing(file: ISlackFile, webClient: WebClient): Promise<ISlackFile> {
         if (file.public_url_shared) { return file; }
 
-        this.main.incRemoteCallCounter("files.sharedPublicURL");
-        const response = await rp({
-            uri: "https://slack.com/api/files.sharedPublicURL",
-            method: "POST",
-            form: {
-                file: file.id,
-                token,
-            },
-            json: true,
-        });
+        const response = (await webClient.files.sharedPublicURL({ file: file.id })) as FilesSharedPublicURLResponse;
         if (!response || !response.file || !response.file.permalink_public) {
             log.warn("Could not find sharedPublicURL: " + JSON.stringify(response));
             throw Error("files.sharedPublicURL didn't return a shareable url");

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -114,18 +114,18 @@ export abstract class BaseSlackHandler {
                 channel: id,
                 token,
             },
-            uri: "https://slack.com/api/channels.info",
+            uri: "https://slack.com/api/conversations.info",
         };
-        this.main.incRemoteCallCounter("channels.info");
+        this.main.incRemoteCallCounter("conversations.info");
         try {
             const response = await rp(channelsInfoApiParams);
             if (response && response.channel && response.channel.name) {
-                log.info(`channels.info: ${id} mapped to ${response.channel.name}`);
+                log.info(`conversations.info: ${id} mapped to ${response.channel.name}`);
                 return response.channel.name;
             }
-            log.info("channels.info returned no result for " + id);
+            log.info("conversations.info returned no result for " + id);
         } catch (err) {
-            log.error("Caught error handling channels.info:" + err);
+            log.error("Caught error handling conversations.info:" + err);
         }
         return id;
     }

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -21,6 +21,8 @@ import { Main, METRIC_SENT_MESSAGES } from "./Main";
 import { default as substitutions, getFallbackForMissingEmoji, ISlackToMatrixResult } from "./substitutions";
 import * as emoji from "node-emoji";
 import { ISlackMessageEvent } from "./BaseSlackHandler";
+import { WebClient, WebAPICallResult } from "@slack/web-api";
+import { TeamInfoResponse, AuthTestResponse, UsersInfoResponse } from "./SlackResponses";
 
 const log = Logging.get("BridgedRoom");
 
@@ -133,7 +135,11 @@ export class BridgedRoom {
         return this.matrixATime;
     }
 
-    public static fromEntry(main: Main, entry: any) {
+    public get SlackClient() {
+        return this.botClient;
+    }
+
+    public static fromEntry(main: Main, entry: any, botClient?: WebClient) {
         return new BridgedRoom(main, {
             access_scopes: entry.remote.access_scopes,
             access_token: entry.remote.access_token,
@@ -148,7 +154,7 @@ export class BridgedRoom {
             slack_user_id: entry.remote.slack_user_id,
             slack_user_token: entry.remote.slack_user_token,
             slack_webhook_uri: entry.remote.webhook_uri,
-        });
+        }, botClient);
     }
 
     private matrixRoomId: string;
@@ -175,7 +181,7 @@ export class BridgedRoom {
      */
     private dirty: boolean;
 
-    constructor(private main: Main, opts: IBridgedRoomOpts) {
+    constructor(private main: Main, opts: IBridgedRoomOpts, private botClient?: WebClient) {
 
         if (!opts.inbound_id) {
             throw new Error("BridgedRoom requires an inbound ID");
@@ -254,7 +260,7 @@ export class BridgedRoom {
     }
 
     public async onMatrixReaction(message: any) {
-        if (!this.SlackBotToken) { return; }
+        if (!this.botClient) { return; }
 
         const relatesTo = message.content["m.relates_to"];
         const eventStore = this.main.eventStore;
@@ -281,28 +287,13 @@ export class BridgedRoom {
 
         // TODO: This only works once from matrix as we are sending the event as the
         // bot user.
-        const body = {
+        const res = await this.botClient.reactions.add({
             as_user: false,
             channel: this.slackChannelId,
             name: emojiKeyName,
             timestamp: event.remoteEventId,
-        };
+        });
 
-        const sendMessageParams = {
-            body,
-            headers: {},
-            json: true,
-            method: "POST",
-            uri: "https://slack.com/api/reactions.add",
-        };
-
-        if (this.slackBotToken) {
-            sendMessageParams.headers = {
-                Authorization: "Bearer " + this.slackBotToken,
-            };
-        }
-
-        const res = await rp(sendMessageParams);
         if (!res) {
             log.error("HTTP Error: ", res);
             return;
@@ -313,7 +304,7 @@ export class BridgedRoom {
     }
 
     public async onMatrixRedaction(message: any) {
-        if (!this.slackBotToken) { return; }
+        if (!this.botClient) { return; }
         const event = await this.main.eventStore.getEntryByMatrixId(message.room_id, message.redacts);
 
         // If we don't get an event then exit
@@ -322,27 +313,12 @@ export class BridgedRoom {
             return;
         }
 
-        const body = {
+        const res = await this.botClient.chat.delete({
             as_user: false,
-            channel: this.slackChannelId,
+            channel: this.slackChannelId!,
             ts: event.remoteEventId,
-        };
+        });
 
-        const sendMessageParams = {
-            body,
-            headers: {},
-            json: true,
-            method: "POST",
-            uri: "https://slack.com/api/chat.delete",
-        };
-
-        if (this.slackBotToken) {
-            sendMessageParams.headers = {
-                Authorization: `Bearer ${this.slackBotToken}`,
-            };
-        }
-
-        const res = await rp(sendMessageParams);
         if (!res) {
             log.error("HTTP Error: ", res);
         }
@@ -350,7 +326,7 @@ export class BridgedRoom {
     }
 
     public async onMatrixEdit(message: any) {
-        if (!this.slackWebhookUri && !this.slackBotToken) { return; }
+        if (!this.botClient) { return; }
 
         const event = await this.main.eventStore.getEntryByMatrixId(
             message.content["m.relates_to"].event_id,
@@ -364,26 +340,13 @@ export class BridgedRoom {
 
         const body = await substitutions.matrixToSlack(newMessage, this.main, this.SlackTeamId!);
 
-        const sendMessageParams = {
-            body: {
-                ts: event.remoteEventId,
-                as_user: false,
-                channel: this.slackChannelId,
-                ...body,
-            },
-            headers: {},
-            json: true,
-            method: "POST",
-            uri: "https://slack.com/api/chat.update",
-        };
+        const res = await this.botClient.chat.update({
+            ts: event.remoteEventId,
+            as_user: false,
+            channel: this.slackChannelId!,
+            ...body,
+        });
 
-        if (this.slackBotToken) {
-            sendMessageParams.headers = {
-                Authorization: `Bearer ${this.slackBotToken}`,
-            };
-        }
-
-        const res = await rp(sendMessageParams);
         this.main.incCounter(METRIC_SENT_MESSAGES, {side: "remote"});
         if (!res) {
             log.error("HTTP Error: ", res);
@@ -395,60 +358,55 @@ export class BridgedRoom {
     }
 
     public async onMatrixMessage(message: any) {
-        if (!this.slackWebhookUri && !this.slackBotToken) { return; }
+        if (!this.slackWebhookUri && !this.botClient) { return; }
 
         const user = this.main.getOrCreateMatrixUser(message.user_id);
         message = await this.stripMatrixReplyFallback(message);
         const matrixToSlackResult = await substitutions.matrixToSlack(message, this.main, this.SlackTeamId!);
         const body: ISlackChatMessagePayload = {
             ...matrixToSlackResult,
+            username: user.getDisplaynameForRoom(message.room_id) || matrixToSlackResult.username,
         };
-        const uri = (this.slackBotToken) ? "https://slack.com/api/chat.postMessage" : this.slackWebhookUri;
-
-        const sendMessageParams = {
-            body,
-            headers: {},
-            json: true,
-            method: "POST",
-            uri: uri!,
-        };
-
-        if (this.slackBotToken) {
-            sendMessageParams.headers = {
-                Authorization: `Bearer ${this.slackBotToken}`,
-            };
-            // See https://api.slack.com/methods/chat.postMessage#authorship
-            // Setting as_user to false means "When the as_user parameter is set to
-            // false, messages are posted as "bot_messages", with message authorship
-            // attributed to the user name"
-            sendMessageParams.body.as_user = false;
-            sendMessageParams.body.channel = this.slackChannelId;
-        }
-
-        sendMessageParams.body.username = user.getDisplaynameForRoom(message.room_id)
-                                          || sendMessageParams.body.username;
 
         const reply = await this.findParentReply(message);
         if (reply !== message.event_id) {
             // We have a reply
             const parentStoredEvent = await this.main.eventStore.getEntryByMatrixId(message.room_id, reply);
-            sendMessageParams.body.thread_ts = parentStoredEvent.remoteEventId;
+            body.thread_ts = parentStoredEvent.remoteEventId;
         }
 
         const avatarUrl = user.getAvatarUrlForRoom(message.room_id);
 
         if (avatarUrl && avatarUrl.indexOf("mxc://") === 0) {
-            sendMessageParams.body.icon_url = this.main.getUrlForMxc(avatarUrl);
+            body.icon_url = this.main.getUrlForMxc(avatarUrl);
         }
 
         user.bumpATime();
         this.matrixATime = Date.now() / 1000;
-        const res = await rp(sendMessageParams);
+        let res: WebAPICallResult;
+        if (this.botClient) {
+            res = await this.botClient.chat.postMessage({
+                ...body,
+                as_user: false,
+                channel: this.slackChannelId!,
+            });
+        } else {
+            const sendMessageParams = {
+                body,
+                headers: {},
+                json: true,
+                method: "POST",
+                uri: this.slackWebhookUri!,
+            };
+            res = await rp(sendMessageParams);
+        }
+
         this.main.incCounter(METRIC_SENT_MESSAGES, {side: "remote"});
-        if (!res) {
+        if (!res.ok) {
             log.error("HTTP Error: ", res);
             return;
         }
+
         // Add this event to the event store
         const event = new StoredEvent(message.room_id, message.event_id, this.slackChannelId, res.ts);
         this.main.eventStore.upsertEvent(event);
@@ -492,15 +450,9 @@ export class BridgedRoom {
     }
 
     public async refreshTeamInfo() {
-        if (!this.slackBotToken) { return; }
+        if (!this.botClient) { return; }
 
-        const response = await rp({
-            uri: "https://slack.com/api/team.info",
-            json: true,
-            qs: {
-                token: this.slackBotToken,
-            },
-        });
+        const response = (await this.botClient.team.info()) as TeamInfoResponse;
         if (!response.team) { return; }
 
         this.setValue("SlackTeamDomain", response.team.domain);
@@ -508,28 +460,15 @@ export class BridgedRoom {
     }
 
     public async refreshUserInfo() {
-        if (!this.slackBotToken) { return; }
+        if (!this.botClient) { return; }
 
-        const testRes = await rp({
-            uri: "https://slack.com/api/auth.test",
-            json: true,
-            qs: {
-                token: this.slackBotToken,
-            },
-        });
+        const testRes = (await this.botClient.auth.test()) as AuthTestResponse;
 
         log.debug("auth.test res:", testRes);
         if (!testRes.user_id) { return; }
         this.setValue("slackUserId", testRes.user_id);
 
-        const usersRes = await rp({
-            uri: "https://slack.com/api/users.info",
-            json: true,
-            qs: {
-                token: this.slackBotToken,
-                user: testRes.user_id,
-            },
-        });
+        const usersRes = (await this.botClient.users.info({ user: testRes.user_id })) as UsersInfoResponse;
         if (!usersRes.user || !usersRes.user.profile) { return; }
         this.setValue("slackBotId", usersRes.user.profile.bot_id);
     }

--- a/src/IConfig.ts
+++ b/src/IConfig.ts
@@ -17,6 +17,7 @@ limitations under the License.
 // This should follow the format in slack-config-schema.yaml
 
 type LogEnum = "error"|"warn"| "info"|"debug"|"off";
+import { WebClientOptions } from "@slack/web-api";
 
 export interface IConfig {
     slack_hook_port: number;
@@ -52,6 +53,7 @@ export interface IConfig {
         redirect_prefix?: string;
     };
 
+    slack_client_opts?: WebClientOptions;
     enable_metrics: boolean;
 
     dbdir: string;

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -758,9 +758,9 @@ export class Main {
 
         if (teamToken) {
             room.SlackBotToken = teamToken;
-            this.incRemoteCallCounter("channels.info");
+            this.incRemoteCallCounter("conversations.info");
             const response = await rp({
-                url: "https://slack.com/api/channels.info",
+                url: "https://slack.com/api/conversations.info",
                 json: true,
                 qs: {
                     channel: opts.slack_channel_id,
@@ -769,7 +769,7 @@ export class Main {
             });
 
             if (!response.ok) {
-                log.error(`channels.info for ${opts.slack_channel_id} errored:`, response);
+                log.error(`conversations.info for ${opts.slack_channel_id} errored:`, response);
                 throw Error("Failed to get channel info");
             }
 

--- a/src/Provisioning.ts
+++ b/src/Provisioning.ts
@@ -136,7 +136,6 @@ commands.channels = new Command({
     async func(main, req, res, userId, teamId) {
         const store = main.userStore;
         log.debug(`${userId} requested their teams`);
-        main.incRemoteCallCounter("conversations.list");
         const matrixUser = await store.getMatrixUser(userId);
         const isAllowed = matrixUser !== null &&
             Object.values(matrixUser.get("accounts") as {[key: string]: {team_id: string}}).find((acct) =>

--- a/src/Provisioning.ts
+++ b/src/Provisioning.ts
@@ -19,6 +19,7 @@ import * as rp from "request-promise-native";
 import { Request, Response} from "express";
 import { Main } from "./Main";
 import { HTTP_CODES } from "./BaseSlackHandler";
+import { ConversationsListResponse } from "./SlackResponses";
 
 const log = Logging.get("Provisioning");
 
@@ -149,16 +150,12 @@ commands.channels = new Command({
         if (team === null) {
             throw new Error("No team token for this team_id");
         }
-        const response = await rp({
-            url: "https://slack.com/api/conversations.list",
-            json: true,
-            qs: {
-                exclude_archived: true,
-                limit: 100,
-                token: team.bot_token,
-                types: "public_channel",
-            },
-        });
+        const cli = await main.createOrGetTeamClient(teamId, team.bot_token);
+        const response = (await cli.conversations.list({
+            exclude_archived: true,
+            limit: 100, // TODO: Pagination
+            types: "public_channel", // TODO: In order to show private channels, we need the identity of the caller.
+        })) as ConversationsListResponse;
         if (!response.ok) {
             log.error(`Failed trying to fetch channels for ${teamId}.`, response);
             res.status(HTTP_CODES.SERVER_ERROR).json({error: "Failed to fetch channels"});
@@ -166,6 +163,7 @@ commands.channels = new Command({
         }
         res.json({
             channels: response.channels.map((chan) => ({
+                // We deliberately filter out extra information about a channel here
                 id: chan.id,
                 name: chan.name,
                 purpose: chan.purpose,

--- a/src/SlackHookHandler.ts
+++ b/src/SlackHookHandler.ts
@@ -217,7 +217,11 @@ export class SlackHookHandler extends BaseSlackHandler {
         }
 
         const text = params.text as string;
-        const lookupRes = await this.lookupMessage(params.channel_id as string, params.timestamp as string, room.SlackClient);
+        const lookupRes = await this.lookupMessage(
+            params.channel_id as string,
+            params.timestamp as string,
+            room.SlackClient,
+        );
 
         if (!lookupRes.message) {
             // Converting params to an object here, as we assume that params is the right shape.

--- a/src/SlackHookHandler.ts
+++ b/src/SlackHookHandler.ts
@@ -18,13 +18,14 @@ import * as fs from "fs";
 import { createServer as httpCreate, RequestListener,
     Server, IncomingMessage, ServerResponse } from "http";
 import { createServer as httpsCreate } from "https";
-import * as rp from "request-promise-native";
 import * as qs from "querystring";
 import { Logging } from "matrix-appservice-bridge";
 import { SlackEventHandler } from "./SlackEventHandler";
 import { BaseSlackHandler, HTTP_CODES, ISlackMessageEvent } from "./BaseSlackHandler";
 import { BridgedRoom } from "./BridgedRoom";
 import { Main } from "./Main";
+import { WebClient } from "@slack/web-api";
+import { ConversationsHistoryResponse } from "./SlackResponses";
 
 const log = Logging.get("SlackHookHandler");
 
@@ -202,9 +203,7 @@ export class SlackHookHandler extends BaseSlackHandler {
         // Only count received messages that aren't self-reflections
         this.main.incCounter("received_messages", {side: "remote"});
 
-        const token = room.AccessToken;
-
-        if (!token) {
+        if (!room.SlackClient) {
             // If we can't look up more details about the message
             // (because we don't have a master token), but it has text,
             // just send the message as text.
@@ -218,7 +217,7 @@ export class SlackHookHandler extends BaseSlackHandler {
         }
 
         const text = params.text as string;
-        const lookupRes = await this.lookupMessage(params.channel_id as string, params.timestamp as string, token);
+        const lookupRes = await this.lookupMessage(params.channel_id as string, params.timestamp as string, room.SlackClient);
 
         if (!lookupRes.message) {
             // Converting params to an object here, as we assume that params is the right shape.
@@ -228,7 +227,7 @@ export class SlackHookHandler extends BaseSlackHandler {
         // Restore the original parameters, because we've forgotten a lot of
         // them by now
         PRESERVE_KEYS.forEach((k) => lookupRes.message[k] = params[k]);
-        lookupRes.message.text = await this.doChannelUserReplacements(lookupRes.message, text, token);
+        lookupRes.message.text = await this.doChannelUserReplacements(lookupRes.message, text, room.SlackClient);
         return room.onSlackMessage(lookupRes.message, lookupRes.content);
     }
 
@@ -313,26 +312,19 @@ export class SlackHookHandler extends BaseSlackHandler {
      * @param {string} timestamp Timestamp when message was received, in seconds
      *     formatted as a float.
      */
-    private async lookupMessage(channelID: string, timestamp: string, token: string): Promise<{
+    private async lookupMessage(channelID: string, timestamp: string, client: WebClient): Promise<{
         // tslint:disable-next-line: no-any
         message: ISlackMessageEvent, content: Buffer|undefined}> {
         // Look up all messages at the exact timestamp we received.
         // This has microsecond granularity, so should return the message we want.
-        const params = {
-            form : {
-                channel: channelID,
-                inclusive: "1",
-                latest: timestamp,
-                oldest: timestamp,
-                token,
-            },
-            json: true,
-            method: "POST",
-            uri: "https://slack.com/api/channels.history",
-        };
-        this.main.incRemoteCallCounter("channels.history");
-        const response = await rp(params);
-        if (!response || !response.messages || response.messages.length === 0) {
+        const response = (await client.conversations.history({
+            channel: channelID,
+            inclusive: true,
+            latest: timestamp,
+            oldest: timestamp,
+        })) as ConversationsHistoryResponse;
+
+        if (!response.ok || !response.messages || response.messages.length === 0) {
             log.warn("Could not find history: " + response);
             throw Error("Could not find history");
         }
@@ -351,8 +343,8 @@ export class SlackHookHandler extends BaseSlackHandler {
 
         if (message.subtype === "file_share") {
             try {
-                message.file = await this.enablePublicSharing(message.file, token);
-                const content = await this.fetchFileContent(message.file);
+                message.file = await this.enablePublicSharing(message.file!, client);
+                const content = await this.fetchFileContent(message.file!);
                 return { message, content };
             } catch (err) {
                 log.error("Failed to get file content: ", err);

--- a/src/SlackResponses.ts
+++ b/src/SlackResponses.ts
@@ -1,4 +1,5 @@
 import { WebAPICallResult } from "@slack/web-api";
+import { ISlackFile } from "./BaseSlackHandler";
 
 /**
  * Taken from https://api.slack.com/methods/team.info
@@ -19,4 +20,96 @@ export interface ConversationsInfoResponse extends WebAPICallResult {
         id: string;
         name: string;
     };
+}
+
+/**
+ * Taken from https://api.slack.com/methods/auth.test
+ */
+export interface AuthTestResponse extends WebAPICallResult {
+    url: string;
+    team: string;
+    user: string;
+    team_id: string;
+    user_id: string;
+}
+
+/**
+ * Taken from https://api.slack.com/methods/users.info
+ */
+export interface UsersInfoResponse extends WebAPICallResult {
+    user: {
+        id: string;
+        name: string;
+        team_id: string;
+        profile: {
+            bot_id?: string;
+        }
+    };
+}
+
+/**
+ * Taken from https://api.slack.com/methods/oauth.access
+ */
+export interface OAuthAccessResponse extends WebAPICallResult {
+    access_token: string;
+    scope: string;
+    team_name: string;
+    team_id: string;
+    bot?: {
+        bot_user_id: string;
+        bot_access_token: string;
+    };
+    user_id: string;
+}
+
+/**
+ * Taken from https://api.slack.com/methods/conversations.list
+ */
+export interface ConversationsListResponse extends WebAPICallResult {
+    channels: {
+        id: string;
+        name: string;
+        purpose: string;
+        topic: string;
+    }[];
+}
+
+/**
+ * Taken from https://api.slack.com/methods/bots.info
+ */
+export interface BotsInfoResponse extends WebAPICallResult {
+    bot: {
+        id: string;
+        name: string;
+        icons: {
+            image_36?: string;
+            image_48?: string;
+            image_72?: string;
+            image_original?: string;
+            image_1024?: string;
+            image_512?: string;
+            image_192?: string;
+        }
+    };
+}
+
+/**
+ * Taken from https://api.slack.com/methods/conversations.history
+ */
+export interface ConversationsHistoryResponse extends WebAPICallResult {
+    messages: {
+      type: string;
+      subtype?: string;
+      file?: ISlackFile;
+      user: string;
+      text: string;
+      ts: string;
+    }[];
+}
+
+/**
+ * Taken from https://api.slack.com/methods/files.sharedPublicURL
+ */
+export interface FilesSharedPublicURLResponse extends WebAPICallResult {
+    file: ISlackFile;
 }

--- a/src/SlackResponses.ts
+++ b/src/SlackResponses.ts
@@ -1,5 +1,5 @@
 import { WebAPICallResult } from "@slack/web-api";
-import { ISlackFile } from "./BaseSlackHandler";
+import { ISlackFile, ISlackUser, ISlackMessageEvent } from "./BaseSlackHandler";
 
 /**
  * Taken from https://api.slack.com/methods/team.info
@@ -37,14 +37,7 @@ export interface AuthTestResponse extends WebAPICallResult {
  * Taken from https://api.slack.com/methods/users.info
  */
 export interface UsersInfoResponse extends WebAPICallResult {
-    user: {
-        id: string;
-        name: string;
-        team_id: string;
-        profile: {
-            bot_id?: string;
-        }
-    };
+    user?: ISlackUser;
 }
 
 /**
@@ -97,14 +90,7 @@ export interface BotsInfoResponse extends WebAPICallResult {
  * Taken from https://api.slack.com/methods/conversations.history
  */
 export interface ConversationsHistoryResponse extends WebAPICallResult {
-    messages: {
-      type: string;
-      subtype?: string;
-      file?: ISlackFile;
-      user: string;
-      text: string;
-      ts: string;
-    }[];
+    messages: ISlackMessageEvent[];
 }
 
 /**

--- a/src/SlackResponses.ts
+++ b/src/SlackResponses.ts
@@ -1,0 +1,22 @@
+import { WebAPICallResult } from "@slack/web-api";
+
+/**
+ * Taken from https://api.slack.com/methods/team.info
+ */
+export interface TeamInfoResponse extends WebAPICallResult {
+    team: {
+        id: string;
+        name: string;
+        domain: string;
+    };
+}
+
+/**
+ * Taken from https://api.slack.com/methods/conversations.info
+ */
+export interface ConversationsInfoResponse extends WebAPICallResult {
+    channel: {
+        id: string;
+        name: string;
+    };
+}

--- a/src/substitutions.ts
+++ b/src/substitutions.ts
@@ -38,7 +38,7 @@ interface IFirstWordMap {
 }
 
 export interface ISlackToMatrixResult {
-        link_names: number;  // This no longer works for nicks but is needed to make @channel work.
+        link_names: boolean;  // This no longer works for nicks but is needed to make @channel work.
         text: string;
         username: string;
         attachments: undefined|[{
@@ -145,7 +145,7 @@ class Substitutions {
 
         // tslint:disable-next-line: no-any
         const ret: ISlackToMatrixResult = {
-            link_names: 1,  // This no longer works for nicks but is needed to make @channel work.
+            link_names: true,  // This no longer works for nicks but is needed to make @channel work.
             text: modifiedBody,
             username: event.user_id,
             attachments: undefined,


### PR DESCRIPTION
Sorry about the size of this one, but it was sort of unavoidable.

This PR changes the bridge significantly so that we now rely on `@slack/web-api` rather than doing HTTP calls ourselves, which reduces the amount of maintenance needed somewhat. API responses now also are typed and based off the slack documentation.

This PR can be treated separate from #164, but should be merged in beforehand ideally.

![image](https://user-images.githubusercontent.com/2072976/63864010-08733480-c9a7-11e9-9cc5-bc3164cbe973.png)

- pictured: reviewer wondering why these PRs are so massive
