### PR TITLE
Ensure we do not bridge events for teams using RTM

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -110,6 +110,9 @@ export class Main {
 
     private teamClients: Map<string, WebClient> = new Map();
 
+    // track which teams are using the rtm client.
+    private rtmTeams: Set<string> = new Set();
+
     constructor(public readonly config: IConfig) {
         if (config.oauth2) {
             this.oauth2 = new OAuth2({
@@ -159,6 +162,10 @@ export class Main {
         if (config.enable_metrics) {
             this.initialiseMetrics();
         }
+    }
+
+    public teamIsUsingRtm(teamId: string): boolean {
+        return this.rtmTeams.has(teamId);
     }
 
     public getIntent(userId: string) {

--- a/src/SlackHookHandler.ts
+++ b/src/SlackHookHandler.ts
@@ -102,7 +102,10 @@ export class SlackHookHandler extends BaseSlackHandler {
                     const eventPayload = JSON.parse(body) as ISlackEventPayload;
                     if (eventPayload.type === "url_verification") {
                         this.eventHandler.onVerifyUrl(eventPayload.challenge!, eventsResponse);
-                    } else if (eventPayload.type === "event_callback") {
+                        // if RTM is enabled, don't handle this event. We should have assigned a RTM client to the team.
+                    } else if (eventPayload.type === "event_callback" &&
+                               this.main.teamIsUsingRtm(eventPayload.team_id)
+                    ) {
                         this.eventHandler.handle(
                             // The event can take many forms.
                             // tslint:disable-next-line: no-any


### PR DESCRIPTION
This is a small fix to stop us double bridging messages when events and RTM are enabled at the same time.