### PR TITLE
Hs/fix linking token issues

### DIFF
--- a/src/AdminCommands.ts
+++ b/src/AdminCommands.ts
@@ -135,10 +135,14 @@ export class AdminCommands {
                 respond("Bridged Room:");
                 respond("  Status: " + bridgedRoom.getStatus());
                 respond("  Slack Name: " + bridgedRoom.SlackChannelName || "PENDING");
-                respond("  Webhook URI: " + bridgedRoom.SlackWebhookUri);
+                respond("  Slack Team: " + bridgedRoom.SlackTeamId || "PENDING");
+                if (bridgedRoom.SlackWebhookUri) {
+                    respond("  Webhook URI: " + bridgedRoom.SlackWebhookUri);
+                }
                 respond("  Inbound ID: " + bridgedRoom.InboundId);
                 respond("  Inbound URL: " + this.main.getInboundUrlForRoom(bridgedRoom));
                 respond("  Matrix room ID: " + bridgedRoom.MatrixRoomId);
+                respond("  Using RTM: " + this.main.teamIsUsingRtm(bridgedRoom.SlackTeamId!));
 
                 if (this.main.oauth2) {
                     const authUrl = this.main.oauth2.makeAuthorizeURL(

--- a/src/AdminCommands.ts
+++ b/src/AdminCommands.ts
@@ -178,9 +178,16 @@ export class AdminCommands {
                     respond("Room is now " + r.getStatus());
                     if (r.SlackWebhookUri) {
                         respond("Inbound URL is " + this.main.getInboundUrlForRoom(r));
+                    } else {
+                        respond("Remember to invite the slack bot to the slack channel.");
                     }
                 } catch (ex) {
-                    respond("Cannot link - " + ex );
+                    log.warn("Failed to link channel", ex);
+                    if ((ex as Error).message === "Failed to get channel info") {
+                        respond("Cannot link - Bot doesn't have visibility on channel. Is it invited on slack?");
+                    } else {
+                        respond("Cannot link - " + ex);
+                    }
                 }
             },
             {

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -478,6 +478,10 @@ export class BridgedRoom {
         await Promise.all(promises);
     }
 
+    public setBotClient(slackClient: WebClient) {
+        this.botClient = slackClient;
+    }
+
     public async refreshTeamInfo() {
         if (!this.botClient) { return; }
 

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -576,7 +576,8 @@ export class Main {
             return;
         }
 
-        if (this.config.matrix_admin_room && ev.room_id === this.config.matrix_admin_room) {
+        if (this.config.matrix_admin_room && ev.room_id === this.config.matrix_admin_room &&
+            ev.type === "m.room.message") {
             try {
                 await this.onMatrixAdminMessage(ev);
             } catch (e) {

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -816,20 +816,14 @@ export class Main {
         const cli = await this.createOrGetTeamClient(opts.team_id!, teamToken!);
 
         if (teamToken) {
-            room.SlackBotToken = teamToken;
-            // Join the channel. If the bot is already joined then this will no-op.
-            const joinRes = await cli.conversations.join({
-                channel: opts.slack_channel_id!,
-            });
-            if (!joinRes.ok) {
-                throw Error("Bot could not join channel");
-            }
-            const infoRes = (await cli.conversations.info()) as ConversationsInfoResponse;
+            // PSA: Bots cannot join channels, they have a limited set of APIs https://api.slack.com/methods/bots.info
 
+            const infoRes = (await cli.conversations.info()) as ConversationsInfoResponse;
             if (!infoRes.ok) {
                 log.error(`conversations.info for ${opts.slack_channel_id} errored:`, infoRes);
                 throw Error("Failed to get channel info");
             }
+            room.SlackBotToken = teamToken;
 
             room.SlackChannelName = infoRes.channel.name;
             await Promise.all([


### PR DESCRIPTION
This PR fixes a few bugs that have spawned around the RTM client/ slack http apis PRs. It fixes:

- We no longer try to join a room as a bot, because slack forbid it.
- Admin room events are filtered before being handled.
- `!show` has been modified to be more helpful when debugging non-webhook rooms
- `actionLink` now crucially binds a `WebClient` to `BridgedRoom` before trying to fetch team info.