### PR TITLE
Fix race when trying to create more than one RTM client for a team

### DIFF
--- a/src/IConfig.ts
+++ b/src/IConfig.ts
@@ -50,7 +50,11 @@ export interface IConfig {
         redirect_prefix?: string;
     };
 
-    enable_rtm: boolean;
+    rtm?: {
+        enable: boolean;
+        log_level?: string;
+    };
+
     slack_hook_port?: number;
     slack_client_opts?: WebClientOptions;
     enable_metrics: boolean;

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -753,11 +753,11 @@ export class Main {
 
         await Promise.all(entries.map(async (entry) => {
             const hasToken = entry.remote.slack_team_id && entry.remote.slack_bot_token;
-
             let cli: WebClient|undefined;
             try {
-                cli = !hasToken ? undefined : await this.createOrGetTeamClient(
-                    entry.remote.slack_team_id!, entry.remote.slack_bot_token!);
+                if (hasToken) {
+                    cli = await this.createOrGetTeamClient(entry.remote.slack_team_id!, entry.remote.slack_bot_token!);
+                }
             } catch (ex) {
                 log.error(`Failed to track room ${entry.matrix_id} ${entry.remote.name}:`, ex);
             }

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -761,6 +761,9 @@ export class Main {
             } catch (ex) {
                 log.error(`Failed to track room ${entry.matrix_id} ${entry.remote.name}:`, ex);
             }
+            if (!cli && !entry.remote.webhook_uri) { // Do not warn if this is a webhook.
+                log.warn(`${entry.remote.name} ${entry.remote.id} does not have a WebClient and will not be able to issue slack requests`);
+            }
             const room = BridgedRoom.fromEntry(this, entry, cli);
             await this.addBridgedRoom(room);
             this.stateStorage.trackRoom(entry.matrix_id);

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -142,7 +142,7 @@ export class Main {
             domain: config.homeserver.server_name,
             eventStore: path.join(dbdir, "event-store.db"),
             homeserverUrl: config.homeserver.url,
-            registration: registration,
+            registration,
             roomStore: path.join(dbdir, "room-store.db"),
             userStore: path.join(dbdir, "user-store.db"),
         });

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -119,8 +119,8 @@ export class Main {
             });
         }
 
-        if (!config.enable_rtm && (!config.slack_hook_port || !config.inbound_uri_prefix)) {
-            throw Error("Neither enable_rtm nor slack_hook_port|inbound_uri_prefix is defined in the config." +
+        if ((!config.rtm || !config.rtm.enable) && (!config.slack_hook_port || !config.inbound_uri_prefix)) {
+            throw Error("Neither rtm.enable nor slack_hook_port|inbound_uri_prefix is defined in the config." +
             "The bridge must define a listener in order to run");
         }
 
@@ -147,7 +147,8 @@ export class Main {
             userStore: path.join(dbdir, "user-store.db"),
         });
 
-        if (config.enable_rtm) {
+        if (config.rtm && config.rtm.enable) {
+            log.info("Enabled RTM");
             this.slackRtm = new SlackRTMHandler(this);
         }
 

--- a/src/SlackHookHandler.ts
+++ b/src/SlackHookHandler.ts
@@ -104,7 +104,7 @@ export class SlackHookHandler extends BaseSlackHandler {
                         this.eventHandler.onVerifyUrl(eventPayload.challenge!, eventsResponse);
                         // If RTM is enabled for this team, do not handle the event.
                         // Slack will push us events for all connected teams to our bots,
-                        // but this will cause duplicates if the team is ALSO using RTM since.
+                        // but this will cause duplicates if the team is ALSO using RTM.
                     } else if (eventPayload.type === "event_callback" &&
                                !this.main.teamIsUsingRtm(eventPayload.team_id)
                     ) {

--- a/src/SlackHookHandler.ts
+++ b/src/SlackHookHandler.ts
@@ -102,7 +102,9 @@ export class SlackHookHandler extends BaseSlackHandler {
                     const eventPayload = JSON.parse(body) as ISlackEventPayload;
                     if (eventPayload.type === "url_verification") {
                         this.eventHandler.onVerifyUrl(eventPayload.challenge!, eventsResponse);
-                        // if RTM is enabled, don't handle this event. We should have assigned a RTM client to the team.
+                        // If RTM is enabled for this team, do not handle the event.
+                        // Slack will push us events for all connected teams to our bots,
+                        // but this will cause duplicates if the team is ALSO using RTM since.
                     } else if (eventPayload.type === "event_callback" &&
                                !this.main.teamIsUsingRtm(eventPayload.team_id)
                     ) {

--- a/src/SlackHookHandler.ts
+++ b/src/SlackHookHandler.ts
@@ -104,7 +104,7 @@ export class SlackHookHandler extends BaseSlackHandler {
                         this.eventHandler.onVerifyUrl(eventPayload.challenge!, eventsResponse);
                         // if RTM is enabled, don't handle this event. We should have assigned a RTM client to the team.
                     } else if (eventPayload.type === "event_callback" &&
-                               this.main.teamIsUsingRtm(eventPayload.team_id)
+                               !this.main.teamIsUsingRtm(eventPayload.team_id)
                     ) {
                         this.eventHandler.handle(
                             // The event can take many forms.

--- a/src/SlackRTMHandler.ts
+++ b/src/SlackRTMHandler.ts
@@ -37,16 +37,18 @@ export class SlackRTMHandler extends SlackEventHandler {
     }
 
     private async startTeamClient(expectedTeam: string, botToken: string) {
+        const LOG_LEVELS = ["debug", "info", "warn", "error", "silent"];
         const connLog = Logging.get(`RTM-${expectedTeam.substr(0, LOG_TEAM_LEN)}`);
+        const logLevel = LOG_LEVELS.indexOf(this.main.config.rtm!.log_level || "silent");
         const rtm = new RTMClient(botToken, {
             logLevel: LogLevel.DEBUG, // We will filter this ourselves.
             logger: {
                 setLevel: () => {},
                 setName: () => {}, // We handle both of these ourselves.
-                debug: connLog.debug.bind(connLog),
-                warn: connLog.warn.bind(connLog),
-                info: connLog.info.bind(connLog),
-                error: connLog.error.bind(connLog),
+                debug: logLevel <= 0 ? connLog.debug.bind(connLog) : () => {},
+                warn: logLevel <= 1 ? connLog.warn.bind(connLog) : () => {},
+                info: logLevel <= 2 ? connLog.info.bind(connLog) : () => {},
+                error: logLevel <= 3 ? connLog.error.bind(connLog) : () => {},
             },
         });
 

--- a/src/SlackRTMHandler.ts
+++ b/src/SlackRTMHandler.ts
@@ -31,7 +31,9 @@ export class SlackRTMHandler extends SlackEventHandler {
                 log.warn("Failed to create RTM client");
             }
         }
-        this.rtmClients.set(expectedTeam, this.startTeamClient(expectedTeam, botToken));
+        const promise = this.startTeamClient(expectedTeam, botToken);
+        this.rtmClients.set(expectedTeam, promise);
+        await promise;
     }
 
     private async startTeamClient(expectedTeam: string, botToken: string) {

--- a/src/SlackRTMHandler.ts
+++ b/src/SlackRTMHandler.ts
@@ -1,7 +1,3 @@
-/**
- * This class handles events coming in from slack.
- */
-
 import { RTMClient, LogLevel } from "@slack/rtm-api";
 import { Main, ISlackTeam } from "./Main";
 import { SlackEventHandler } from "./SlackEventHandler";


### PR DESCRIPTION
This can happen when multiple channels belong to the same team and try to call the start function. This code returns early and stores a promise to ensure that future calls will await the promise.