### PR TITLE
Fix issue where DM creation can race

### DIFF
--- a/changelog.d/219.bugfix
+++ b/changelog.d/219.bugfix
@@ -1,0 +1,1 @@
+Fix issue where DMs can race while the DM room is being created.

--- a/src/SlackRTMHandler.ts
+++ b/src/SlackRTMHandler.ts
@@ -18,10 +18,12 @@ const LOG_TEAM_LEN = 12;
 export class SlackRTMHandler extends SlackEventHandler {
     private rtmTeamClients: Map<string, Promise<RTMClient>>; // team -> client
     private rtmUserClients: Map<string, RTMClient>; // team:mxid -> client
+    private messageQueueBySlackId: Map<string, Promise<void>>; // teamid+channelid -> promise
     constructor(main: Main) {
         super(main);
         this.rtmTeamClients = new Map();
         this.rtmUserClients = new Map();
+        this.messageQueueBySlackId = new Map();
     }
 
     public async getUserClient(teamId: string, matrixId: string): Promise<RTMClient|undefined> {
@@ -43,17 +45,27 @@ export class SlackRTMHandler extends SlackEventHandler {
         }
         let teamInfo: ISlackTeam;
         rtm.on("message", async (e) => {
-            const chanInfo = (await slackClient!.conversations.info({channel: e.channel})) as ConversationsInfoResponse;
-            // is_private is unreliably set.
-            chanInfo.channel.is_private = chanInfo.channel.is_im || chanInfo.channel.is_group;
-            if (chanInfo.channel.is_channel || !chanInfo.channel.is_private) {
-                // Never forward messages on from the users workspace if it's public
+            const messageQueueKey = `${puppetEntry.teamId}:${e.channel}`;
+            // This is used to ensure that we do not race messages for a single channel.
+            if (this.messageQueueBySlackId.has(messageQueueKey)) {
+                await this.messageQueueBySlackId.get(messageQueueKey);
             }
-            // Sneaky hack to set the domain on messages.
-            e.team_id = teamInfo.id;
-            e.team_domain = teamInfo.domain;
-            e.user_id = e.user;
-            await this.handleUserMessage(chanInfo, e, slackClient, puppetEntry);
+            const messagePromise = (async () => {
+                const chanInfo = (await slackClient!.conversations.info({channel: e.channel})) as ConversationsInfoResponse;
+                // is_private is unreliably set.
+                chanInfo.channel.is_private = chanInfo.channel.is_im || chanInfo.channel.is_group;
+                if (chanInfo.channel.is_channel || !chanInfo.channel.is_private) {
+                    // Never forward messages on from the users workspace if it's public
+                }
+                // Sneaky hack to set the domain on messages.
+                e.team_id = teamInfo.id;
+                e.team_domain = teamInfo.domain;
+                e.user_id = e.user;
+
+                const messageF = this.handleUserMessage(chanInfo, e, slackClient, puppetEntry);
+            })();
+            this.messageQueueBySlackId.set(messageQueueKey, messagePromise);
+            await messagePromise;
         });
         this.rtmUserClients.set(key, rtm);
         const { team } = await rtm.start();

--- a/src/SlackRTMHandler.ts
+++ b/src/SlackRTMHandler.ts
@@ -50,20 +50,7 @@ export class SlackRTMHandler extends SlackEventHandler {
             if (this.messageQueueBySlackId.has(messageQueueKey)) {
                 await this.messageQueueBySlackId.get(messageQueueKey);
             }
-            const messagePromise = (async () => {
-                const chanInfo = (await slackClient!.conversations.info({channel: e.channel})) as ConversationsInfoResponse;
-                // is_private is unreliably set.
-                chanInfo.channel.is_private = chanInfo.channel.is_im || chanInfo.channel.is_group;
-                if (chanInfo.channel.is_channel || !chanInfo.channel.is_private) {
-                    // Never forward messages on from the users workspace if it's public
-                }
-                // Sneaky hack to set the domain on messages.
-                e.team_id = teamInfo.id;
-                e.team_domain = teamInfo.domain;
-                e.user_id = e.user;
-
-                const messageF = this.handleUserMessage(chanInfo, e, slackClient, puppetEntry);
-            })();
+            const messagePromise = this.handleRtmMessage(puppetEntry, slackClient, teamInfo, e);
             this.messageQueueBySlackId.set(messageQueueKey, messagePromise);
             await messagePromise;
         });
@@ -72,6 +59,22 @@ export class SlackRTMHandler extends SlackEventHandler {
         teamInfo = team as ISlackTeam;
 
         log.debug(`Started RTM client for user ${key}`, team);
+    }
+
+    // tslint:disable-next-line: no-any
+    private async handleRtmMessage(puppetEntry: PuppetEntry, slackClient: WebClient, teamInfo: ISlackTeam, e: any) {
+        const chanInfo = (await slackClient!.conversations.info({channel: e.channel})) as ConversationsInfoResponse;
+        // is_private is unreliably set.
+        chanInfo.channel.is_private = chanInfo.channel.is_im || chanInfo.channel.is_group;
+        if (chanInfo.channel.is_channel || !chanInfo.channel.is_private) {
+            // Never forward messages on from the users workspace if it's public
+        }
+        // Sneaky hack to set the domain on messages.
+        e.team_id = teamInfo.id;
+        e.team_domain = teamInfo.domain;
+        e.user_id = e.user;
+
+        return this.handleUserMessage(chanInfo, e, slackClient, puppetEntry);
     }
 
     public teamIsUsingRtm(teamId: string): boolean {

--- a/src/tests/unit/SlackRTMHandlerTest.ts
+++ b/src/tests/unit/SlackRTMHandlerTest.ts
@@ -1,0 +1,36 @@
+/*
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// tslint:disable: no-unused-expression
+
+import { MatrixUser } from "../../MatrixUser";
+import { Main } from "../../Main";
+import { expect } from "chai";
+import { SlackRTMHandler } from "../../SlackRTMHandler";
+import { FakeMain } from "../utils/fakeMain";
+
+function createHandler() {
+    const fakeMain = new FakeMain();
+    return new SlackRTMHandler(fakeMain as unknown as Main);
+}
+
+describe("SlackRTMHandler", () => {
+    // https://github.com/matrix-org/matrix-appservice-slack/issues/212
+    it("should not race messages from RTM clients", () => {
+        const handler = createHandler();
+        handler.startUserClient()
+    });
+});

--- a/src/tests/unit/SlackRTMHandlerTest.ts
+++ b/src/tests/unit/SlackRTMHandlerTest.ts
@@ -49,7 +49,7 @@ describe("SlackRTMHandler", () => {
         const messages = ["Test 1", "Test 2", "Test 3", "Test 4", "Test 5"];
         let wasCalled = 0;
         const allDone = new Promise((resolve, reject) => {
-            handler.handleRtmMessage = async (a,b,c,e) => {
+            handler.handleRtmMessage = async (a, b, c, e) => {
                 wasCalled++;
                 if (wasCalled === 5) {
                     resolve();

--- a/src/tests/utils/fakeMain.ts
+++ b/src/tests/utils/fakeMain.ts
@@ -16,4 +16,3 @@ class FakeClientFactory {
         return {};
     }
 }
-

--- a/src/tests/utils/fakeMain.ts
+++ b/src/tests/utils/fakeMain.ts
@@ -1,6 +1,8 @@
 export class FakeMain {
     public readonly timerFinished: {[eventName: string]: string } = {};
 
+    public clientFactory: FakeClientFactory = new FakeClientFactory();
+
     public startTimer(eventName: string) {
         this.timerFinished[eventName] = "notfinished";
         return (reason: {outcome: string}) => {
@@ -8,3 +10,10 @@ export class FakeMain {
         };
     }
 }
+
+class FakeClientFactory {
+    public async getClientForUser(teamId: string, matrixId: string) {
+        return {};
+    }
+}
+


### PR DESCRIPTION
Fixes #212

This can happen when we get multiple messages for a channel while the room is being created. The provided test ensures we queue messages for a given channel.