### PR TITLE
Add LRU caching to matrix and slack users

### DIFF
--- a/changelog.d/228.feature
+++ b/changelog.d/228.feature
@@ -1,0 +1,1 @@
+Add caching option to config to limit the number of stored users in memory

--- a/package-lock.json
+++ b/package-lock.json
@@ -2189,6 +2189,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+    },
     "randomstring": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/randomstring/-/randomstring-1.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "nedb": "^1.8.0",
     "node-emoji": "^1.10.0",
     "pg-promise": "^9.0.2",
+    "quick-lru": "^4.0.1",
     "randomstring": "^1",
     "request-promise-native": "^1.0.7",
     "uuid": "^3.3.2",

--- a/src/IConfig.ts
+++ b/src/IConfig.ts
@@ -19,6 +19,11 @@ limitations under the License.
 type LogEnum = "error"|"warn"| "info"|"debug"|"off";
 import { WebClientOptions } from "@slack/web-api";
 
+export const CACHING_DEFAULTS = {
+    ghostUserCache: 100,
+    matrixUserCache: 100,
+};
+
 export interface IConfig {
     inbound_uri_prefix?: string;
     username_prefix: string;
@@ -34,6 +39,11 @@ export interface IConfig {
     tls?: {
         key_file: string;
         crt_file: string;
+    };
+
+    caching?: {
+        ghostUserCache: number,
+        matrixUserCache: number,
     };
 
     logging: {

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -20,7 +20,7 @@ import { Bridge, PrometheusMetrics, StateLookup,
 import * as path from "path";
 import * as randomstring from "randomstring";
 import { WebClient } from "@slack/web-api";
-import { IConfig } from "./IConfig";
+import { IConfig, CACHING_DEFAULTS } from "./IConfig";
 import { OAuth2 } from "./OAuth2";
 import { BridgedRoom } from "./BridgedRoom";
 import { SlackGhost } from "./SlackGhost";
@@ -37,6 +37,7 @@ import { NedbDatastore } from "./datastore/NedbDatastore";
 import { PgDatastore } from "./datastore/postgres/PgDatastore";
 import { SlackClientFactory } from "./SlackClientFactory";
 import { Response } from "express";
+import * as QuickLRU from "quick-lru";
 
 const log = Logging.get("Main");
 
@@ -88,8 +89,8 @@ export class Main {
     private roomsByMatrixRoomId: {[roomId: string]: BridgedRoom} = {};
     private roomsByInboundId: {[inboundId: string]: BridgedRoom} = {};
 
-    private ghostsByUserId: {[userId: string]: SlackGhost} = {};
-    private matrixUsersById: {[userId: string]: MatrixUser} = {};
+    private ghostsByUserId: QuickLRU<string, SlackGhost>;
+    private matrixUsersById: QuickLRU<string, MatrixUser>;
 
     private bridge: Bridge;
 
@@ -119,6 +120,13 @@ export class Main {
                 redirect_prefix: redirectPrefix!,
             });
         }
+
+        if (!config.caching) {
+            config.caching = CACHING_DEFAULTS;
+        }
+
+        this.ghostsByUserId = new QuickLRU({ maxSize: config.caching!.ghostUserCache || CACHING_DEFAULTS.ghostUserCache });
+        this.matrixUsersById = new QuickLRU({ maxSize: config.caching!.matrixUserCache || CACHING_DEFAULTS.matrixUserCache });
 
         if ((!config.rtm || !config.rtm.enable) && (!config.slack_hook_port || !config.inbound_uri_prefix)) {
             throw Error("Neither rtm.enable nor slack_hook_port|inbound_uri_prefix is defined in the config." +
@@ -204,13 +212,11 @@ export class Main {
                 matrixRoomsByAge.bump(now - room.MatrixATime!);
             });
 
-            const countAges = (users: {[key: string]: MatrixUser|SlackGhost}) => {
+            const countAges = (users: QuickLRU<string, MatrixUser|SlackGhost>) => {
                 const counts = new PrometheusMetrics.AgeCounters();
-
-                Object.keys(users).forEach((id) => {
-                    counts.bump(now - users[id].aTime!);
-                });
-
+                for (const id of users.keys()) {
+                    counts.bump(now - users.get(id)!.aTime!);
+                }
                 return counts;
             };
 

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -123,8 +123,8 @@ export class Main {
 
         config.caching = { ...CACHING_DEFAULTS, ...config.caching };
 
-        this.ghostsByUserId = new QuickLRU({ maxSize: config.caching!.ghostUserCache });
-        this.matrixUsersById = new QuickLRU({ maxSize: config.caching!.matrixUserCache });
+        this.ghostsByUserId = new QuickLRU({ maxSize: config.caching.ghostUserCache });
+        this.matrixUsersById = new QuickLRU({ maxSize: config.caching.matrixUserCache });
 
         if ((!config.rtm || !config.rtm.enable) && (!config.slack_hook_port || !config.inbound_uri_prefix)) {
             throw Error("Neither rtm.enable nor slack_hook_port|inbound_uri_prefix is defined in the config." +


### PR DESCRIPTION
We really don't need to store all these users, as we do DB fetches for them anyway. This PR changes the default behavior so we only store 100 of each type in the cache.