### PR TITLE
Migration script fixes for team refactoring

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -374,6 +374,7 @@ export class Main {
     }
 
     public async addBridgedRoom(room: BridgedRoom) {
+        this.rooms.upsertRoom(room);
         if (room.SlackTeamId) {
             if (this.slackRtm) {
                 // This will start a new RTM client for the team, if the team

--- a/src/SlackClientFactory.ts
+++ b/src/SlackClientFactory.ts
@@ -1,5 +1,5 @@
 import { Datastore, TeamEntry } from "./datastore/Models";
-import { WebClient, WebClientOptions } from "@slack/web-api";
+import { WebClient, WebClientOptions, LogLevel } from "@slack/web-api";
 import { Logging } from "matrix-appservice-bridge";
 import { TeamInfoResponse, AuthTestResponse, BotsInfoResponse, UsersInfoResponse } from "./SlackResponses";
 
@@ -158,6 +158,7 @@ export class SlackClientFactory {
                 info: webLog.info.bind(webLog),
                 error: webLog.error.bind(webLog),
             },
+            logLevel: LogLevel.DEBUG,
             ...opts,
         });
         try {

--- a/src/SlackClientFactory.ts
+++ b/src/SlackClientFactory.ts
@@ -18,7 +18,7 @@ interface RequiredConfigOptions {
 export class SlackClientFactory {
     private teamClients: Map<string, WebClient> = new Map();
     private puppets: Map<string, WebClient> = new Map();
-    constructor(private datastore: Datastore, private config: RequiredConfigOptions, private onRemoteCall: (method: string) => void) {
+    constructor(private datastore: Datastore, private config?: RequiredConfigOptions, private onRemoteCall?: (method: string) => void) {
 
     }
 
@@ -140,7 +140,7 @@ export class SlackClientFactory {
     }
 
     private async createTeamClient(token: string) {
-        const opts = this.config.slack_client_opts;
+        const opts = this.config ? this.config.slack_client_opts : undefined;
         const slackClient = new WebClient(token, {
             logger: {
                 setLevel: () => {}, // We don't care about these.
@@ -148,6 +148,7 @@ export class SlackClientFactory {
                 debug: (msg: any[]) => {
                     // non-ideal way to detect calls to slack.
                     webLog.debug.bind(webLog);
+                    if (!this.onRemoteCall) { return; }
                     const match = /apiCall\('([\w\.]+)'\) start/.exec(msg[0]);
                     if (match && match[1]) {
                         this.onRemoteCall(match[1]);

--- a/src/datastore/Models.ts
+++ b/src/datastore/Models.ts
@@ -26,7 +26,7 @@ export interface RoomEntry {
         slack_type?: string;
         id: string;
         name: string;
-        webhook_uri: string;
+        webhook_uri?: string;
         slack_private?: boolean;
         puppet_owner?: string;
     };

--- a/src/scripts/migrateToPostgres.ts
+++ b/src/scripts/migrateToPostgres.ts
@@ -27,6 +27,10 @@ import { NedbDatastore } from "../datastore/NedbDatastore";
 import { PgDatastore } from "../datastore/postgres/PgDatastore";
 import { BridgedRoom } from "../BridgedRoom";
 import { SlackGhost } from "../SlackGhost";
+import { WebClient } from "@slack/web-api";
+import { TeamInfoResponse } from "../SlackResponses";
+import { TeamEntry } from "../datastore/Models";
+import { SlackClientFactory } from "../SlackClientFactory";
 
 Logging.configure({ console: "info" });
 const log = Logging.get("script");
@@ -69,7 +73,9 @@ async function main() {
     );
     const allRooms = await nedb.getAllRooms();
     const allEvents = await nedb.getAllEvents();
-    const allTeams = await nedb.getAllTeams();
+    // the format has changed quite a bit.
+    // tslint:disable-next-line: no-any
+    const allTeams = (await nedb.getAllTeams()) as any[];
     const allSlackUsers = await nedb.getAllUsers(false);
     const allMatrixUsers = await nedb.getAllUsers(true);
 
@@ -78,9 +84,33 @@ async function main() {
     log.info(`Migrating ${allEvents.length} events`);
     log.info(`Migrating ${allSlackUsers.length} slack users`);
     log.info(`Migrating ${allMatrixUsers.length} matrix users`);
+
+    const teamTokenMap: Map<string, string> = new Map(); // token -> teamId.
+
+    const preTeamMigrations = Promise.all(allRooms.map(async (room, i) => {
+        const at = (room.remote as any).access_token;
+        if (!at) {
+            return;
+        }
+        try {
+            if (at) {
+                const cli = new WebClient(at);
+                const team = (await cli.team.info()) as TeamInfoResponse;
+                teamTokenMap.set(at, team.team.id);
+            }
+        } catch (ex) {
+            log.warn(`Failed to authenticate for token, skipping room -> team migration for ${room.remote.name}`);
+        }
+    }));
+
     const roomMigrations = allRooms.map(async (room, i) => {
         // tslint:disable-next-line: no-any
         await pgres.upsertRoom(BridgedRoom.fromEntry(null as any, room));
+        const at = (room.remote as any).access_token;
+        if (teamTokenMap.has(at)) {
+            room.remote.slack_team_id = teamTokenMap.get(at);
+        }
+        // tslint:disable-next-line: no-any
         log.info(`Migrated room ${room.id} (${i + 1}/${allRooms.length})`);
     });
 
@@ -90,13 +120,30 @@ async function main() {
     });
 
     const teamMigrations = allTeams.map(async (team, i) => {
-        await pgres.upsertTeam(team);
-        log.info(`Migrated team ${team.id} ${team.name} (${i + 1}/${allTeams.length})`);
+        const newTeamEntry: TeamEntry = {
+            id: team.team_id || team.id,
+            bot_token: team.bot_token,
+            name: team.team_name || team.name,
+            user_id: team.user_id,
+            bot_id: "", // The following will be fetched during bridge startup
+            domain: "",
+            scopes: "",
+            status: "ok",
+        };
+
+        await pgres.upsertTeam(newTeamEntry);
+        log.info(`Migrated team ${newTeamEntry.id} ${newTeamEntry.name} (${i + 1}/${allTeams.length})`);
     });
 
     const slackUserMigrations = allSlackUsers.map(async (user, i) => {
         // tslint:disable-next-line: no-any
         const ghost = SlackGhost.fromEntry(null as any, user, null);
+        if (!ghost.slackId || !ghost.teamId) {
+            // If the user lacks one of these, it's difficult to identify them. Just drop
+            // them from the cache and rebuild as we go.
+            log.warn(`Skipping slack user ${user.id} because they lack a slackId and/or teamId`);
+            return;
+        }
         await pgres.upsertUser(ghost);
         log.info(`Migrated slack user ${user.id} (${i + 1}/${allSlackUsers.length})`);
     });
@@ -109,10 +156,12 @@ async function main() {
     });
 
     try {
+        await preTeamMigrations;
+        // These must come after team migrations
         await Promise.all(
             roomMigrations.concat(
-                eventMigrations,
                 teamMigrations,
+                eventMigrations,
                 slackUserMigrations,
                 matrixUserMigrations,
             ),


### PR DESCRIPTION
This tweaks the migration script so it *should* migrate the old format stores into the new format with separated team tokens from rooms and all that fancy stuff.

This script has been tested to ensure it works with the 0.3.2 data format.