### PR TITLE
Add snapcraft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ node_modules
 # typescript
 lib
 
+# snaps
+*.snap

--- a/changelog.d/231.feature
+++ b/changelog.d/231.feature
@@ -1,0 +1,1 @@
+Add snapcraft packagine information so that matrix-appservice-slack can be built as a snap package, and published to the snapcraft store.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -24,6 +24,27 @@ $ npm run build
 $ docker pull matrixdotorg/matrix-appservice-slack:latest
 ```
 
+### With snapcraft
+
+NOTE: Currently, the snap for this package is not published on the store.
+      You will need to build the snap package by running `snapcraft` in
+      the top level directory of the checked out source code, and install
+      with `--devmode`.
+
+```sh
+$ snap install --devmode <filename of built snap>.snap
+```
+
+Once this package is published in the snapcraft store, the package can simply
+be installed with
+
+```sh
+$ snap install matrix-appservice-slack
+```
+
+All configuration files must be stored in `/snap/matrix-appservice-slack/common`
+instead of the regular `/etc` directory.
+
 ## How it Works:
 
 The bridge listens to events using the Slack RTM API over websockets, and to

--- a/snap/local/wrapper
+++ b/snap/local/wrapper
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Fail if not running in from the snap 
+: ${SNAP?} ${SNAP_DATA?}
+export PATH=$SNAP/bin:$PATH
+cp -pn $SNAP/config/config.sample.yaml $SNAP_COMMON/config.yaml
+$SNAP/bin/node $SNAP/build/app.js --config $SNAP_COMMON/config.yaml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,60 @@
+name: matrix-appservice-slack
+base: core18
+version: git 
+summary: Matrix appservice bridge for Slack rooms
+description: |
+  This bridge allows you to connect Slack channels to Matrix rooms.
+
+grade: stable 
+confinement: strict 
+
+apps:
+  matrix-appservice-slack: 
+    command: 'bin/matrix-appservice-slack-wrapper'
+    plugs: [network-bind, network]
+    daemon: simple
+parts:
+  nodejs-lts:
+    plugin: nil
+    override-build: |
+      NODE_VERSION=12.13.0
+      case $SNAPCRAFT_ARCH_TRIPLET in
+      x86_64-*)
+        NODE_ARCH="x64"
+        ;;
+      aarch64-*)
+        NODE_ARCH="arm64"
+        ;;
+      arm-linux-gnueabihf)
+        NODE_ARCH="armv7l"
+        ;;
+      powerpc64le-*)
+        NODE_ARCH="ppc64le"
+        ;;
+      s390x-*)
+        NODE_ARCH="s390x"
+        ;;
+      esac
+      echo "Fetching node $NODE_VERSION for $NODE_ARCH"
+      wget "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$NODE_ARCH.tar.xz" -O /tmp/nodejs.tar.xz
+      tar Jxf /tmp/nodejs.tar.xz -C $SNAPCRAFT_PART_INSTALL/ --strip 1
+      rm $SNAPCRAFT_PART_INSTALL/README.md
+      rm $SNAPCRAFT_PART_INSTALL/CHANGELOG.md
+      rm $SNAPCRAFT_PART_INSTALL/LICENSE
+      snapcraftctl build
+  matrix-appservice-slack:
+    source: .
+    plugin: dump
+    build-packages:
+      - make
+      - gcc
+      - g++
+      - binutils
+      - python
+      - git
+    override-build: |
+      npm install
+      snapcraftctl build
+    organize:
+      snap/local/wrapper: bin/matrix-appservice-slack-wrapper
+    after: [nodejs-lts]


### PR DESCRIPTION
Adds necessary wrapper and snapcraft metadata to build and deploy this service as a snap.

If/when this is merged, it will need to be deployed to the snapcraft store. This can be done automatically using snapcraft's GitHub integration or via a CI system. I can also assist to publish the builds if desired. This will allow folks to very easily install this bridge and keep it up to date as new releases are made.

Signed-off-by: James Hebden <james@ec0.io>