### PR TITLE
Do not send messages M->S if we have no content to send

### DIFF
--- a/changelog.d/238.bugfix
+++ b/changelog.d/238.bugfix
@@ -1,0 +1,1 @@
+Do not send messages to slack with no content

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -345,6 +345,11 @@ export class BridgedRoom {
             username: user.getDisplaynameForRoom(message.room_id) || matrixToSlackResult.username,
         };
 
+        if (!body.attachments && !body.text) {
+            // The message type might not be understood. In any case, we can't send something without
+            // text.
+            return;
+        }
         const reply = await this.findParentReply(message);
         let parentStoredEvent: EventEntry | null = null;
         if (reply !== message.event_id) {


### PR DESCRIPTION
The bridge will attempt to send messages that we might not even understand. This should be filtered out before we hit Slack's API.