### PR TITLE
RTM startup fixes

### DIFF
--- a/changelog.d/246.misc
+++ b/changelog.d/246.misc
@@ -1,0 +1,1 @@
+Log more information during startup

--- a/changelog.d/247.bugfix
+++ b/changelog.d/247.bugfix
@@ -1,0 +1,1 @@
+Fix issue where the bridge will not start if a team cannot connect to RTM.

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,13 @@
         "p-cancelable": "^1.1.0",
         "p-queue": "^2.4.2",
         "ws": "^5.2.0"
+      },
+      "dependencies": {
+        "p-queue": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
+          "integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng=="
+        }
       }
     },
     "@slack/types": {
@@ -81,6 +88,11 @@
             "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
           }
+        },
+        "p-queue": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
+          "integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng=="
         }
       }
     },
@@ -1982,9 +1994,20 @@
       }
     },
     "p-queue": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
-      "integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.1.1.tgz",
+      "integrity": "sha512-R9gq36Th88xZ+rWAptN5IXLwqkwA1gagCQhT6ZXQ6RxEfmjb9ZW+UBzRVqv9sm5TQmbbI/TsKgGLbOaA61xR5w==",
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "p-timeout": "^3.1.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+        }
+      }
     },
     "p-retry": {
       "version": "4.1.0",
@@ -1993,6 +2016,14 @@
       "requires": {
         "@types/retry": "^0.12.0",
         "retry": "^0.12.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "minimist": "^1.2",
     "nedb": "^1.8.0",
     "node-emoji": "^1.10.0",
+    "p-queue": "^6.1.1",
     "pg-promise": "^9.0.2",
     "quick-lru": "^4.0.1",
     "randomstring": "^1",

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -786,7 +786,11 @@ export class Main {
         log.info(`Found ${entries.length} room entries in store`);
         const joinedRooms = await roomListPromise;
         await Promise.all(entries.map(async (entry) => {
-            await this.startupLoadRoomEntry(entry, joinedRooms, teamClients);
+            try {
+                await this.startupLoadRoomEntry(entry, joinedRooms, teamClients);
+            } catch (ex) {
+                log.error(`Failed to load entry ${entry.matrix_id}, exception thrown`, ex);
+            }
         }));
 
         if (this.metrics) {

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -783,6 +783,7 @@ export class Main {
         }
 
         const entries = await this.datastore.getAllRooms();
+        log.info(`Found ${entries.length} room entries in store`);
         const joinedRooms = await roomListPromise;
         await Promise.all(entries.map(async (entry) => {
             await this.startupLoadRoomEntry(entry, joinedRooms, teamClients);

--- a/src/SlackClientFactory.ts
+++ b/src/SlackClientFactory.ts
@@ -156,7 +156,7 @@ export class SlackClientFactory {
                     // non-ideal way to detect calls to slack.
                     webLog.debug.bind(webLog);
                     if (!this.onRemoteCall) { return; }
-                    const match = /apiCall\('([\w\.]+)'\) start/.exec(msg[0]);
+                    const match = /apiCall\('([\w\.]+)'\) start/.exec(msg);
                     if (match && match[1]) {
                         this.onRemoteCall(match[1]);
                     }

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -100,7 +100,7 @@ export class SlackEventHandler extends BaseSlackHandler {
                         err = "unknown_event";
                 }
             } catch (ex) {
-                log.warn("Didn't handle event:", ex);
+                log.warn("Didn't handle event");
                 err = ex;
             }
 
@@ -118,6 +118,7 @@ export class SlackEventHandler extends BaseSlackHandler {
             } else if (err === "unknown_event") {
                 endTimer({outcome: "dropped"});
             } else if (err !== null) {
+                log.warn("Error when handing event:", err);
                 endTimer({outcome: "fail"});
             }
 

--- a/src/SlackRoomStore.ts
+++ b/src/SlackRoomStore.ts
@@ -1,4 +1,7 @@
 import { BridgedRoom } from "./BridgedRoom";
+import { Logging } from "matrix-appservice-bridge";
+
+const log = Logging.get("SlackRoomStore");
 
 export class SlackRoomStore {
     private rooms: Set<BridgedRoom> = new Set();
@@ -20,6 +23,7 @@ export class SlackRoomStore {
     }
 
     public upsertRoom(room: BridgedRoom) {
+        log.debug(`upsertRoom ${room.MatrixRoomId}`);
         this.rooms.add(room);
 
         // Remove if the room already exists in the map.
@@ -50,6 +54,7 @@ export class SlackRoomStore {
     }
 
     public removeRoom(room: BridgedRoom) {
+        log.debug(`removeRoom ${room.MatrixRoomId}`);
         this.roomsByMatrixId.delete(room.MatrixRoomId);
 
         if (room.SlackChannelId) {


### PR DESCRIPTION
This PR depends on #246 

This PR addresses several issues from trying to run the bridge against a set of rooms with a mixed set of data (e.g. bot tokens vs user tokens). The PR ensures that the bridge will check tokens before trying to connect using RTM, and will ensure that the bridge will run even if some rooms or teams provoke errors. The PR also ensures that RTM is connected to in parallel for each team, but is limited to a concurrency of 10 at any time. 