### PR TITLE
Fix multi-person DMs being registered as groups

### DIFF
--- a/changelog.d/253.bugfix
+++ b/changelog.d/253.bugfix
@@ -1,0 +1,1 @@
+Fix multi-person DMs being marked with the group (private channel) type rather than the mpim type.

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -183,10 +183,11 @@ export class BridgedRoom {
         this.setValue("isPrivate", chan.is_private);
         if (chan.is_channel) {
             this.setValue("slackType", "channel");
+        } else if (chan.is_mpim) {
+            // note: is_group is also set for mpims, so order is important
+            this.setValue("slackType", "mpim");
         } else if (chan.is_group) {
             this.setValue("slackType", "group");
-        } else if (chan.is_mpim) {
-            this.setValue("slackType", "mpim");
         } else if (chan.is_im) {
             this.setValue("slackType", "im");
         } else {


### PR DESCRIPTION
`is_group` is set in addition to `is_mpim` by the Slack API.