### PR TITLE
Don't log stack traces for unknown teams/rooms/event

### DIFF
--- a/changelog.d/255.bugfix
+++ b/changelog.d/255.bugfix
@@ -1,0 +1,1 @@
+Don't log stack traces for missing rooms, teams or events


### PR DESCRIPTION
Fixes #248 
We currently log a stack trace on all errors, including several which don't need to be reported in such detail. Let's fix that.