### PR TITLE
Don't log the whole response object when an error occurs

### DIFF
--- a/changelog.d/256.bugfix
+++ b/changelog.d/256.bugfix
@@ -1,0 +1,1 @@
+Don't log the whole response object when an error occurs when sending slack requests

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -275,7 +275,7 @@ export class BridgedRoom {
         log.info(`Reaction :${emojiKeyName}: added to ${event.slackTs}`);
 
         if (!res.ok) {
-            log.error("HTTP Error: ", res);
+            log.error("HTTP Error: ", res.error);
             return;
         }
         // TODO: Add this event to the event store
@@ -300,8 +300,9 @@ export class BridgedRoom {
             ts: event.slackTs,
         });
 
-        if (!res) {
-            log.error("HTTP Error: ", res);
+        if (!res.ok) {
+            log.error("HTTP Error: ", res.error);
+            return;
         }
         return res;
     }
@@ -333,8 +334,8 @@ export class BridgedRoom {
         })) as ChatUpdateResponse;
 
         this.main.incCounter(METRIC_SENT_MESSAGES, {side: "remote"});
-        if (!res) {
-            log.error("HTTP Error: ", res);
+        if (!res.ok) {
+            log.error("HTTP Error: ", res.error);
             return;
         }
         // Add this event to the event store
@@ -412,7 +413,7 @@ export class BridgedRoom {
         this.main.incCounter(METRIC_SENT_MESSAGES, {side: "remote"});
 
         if (!res.ok) {
-            log.error("HTTP Error: ", res);
+            log.error("HTTP Error: ", res.error);
             return;
         }
 

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -940,7 +940,7 @@ export class Main {
 
             const infoRes = (await slackClient.conversations.info({ channel: opts.slack_channel_id})) as ConversationsInfoResponse;
             if (!infoRes.ok) {
-                log.error(`conversations.info for ${opts.slack_channel_id} errored:`, infoRes);
+                log.error(`conversations.info for ${opts.slack_channel_id} errored:`, infoRes.error);
                 throw Error("Failed to get channel info");
             }
             room.setBotClient(slackClient);

--- a/src/Provisioning.ts
+++ b/src/Provisioning.ts
@@ -157,7 +157,7 @@ commands.channels = new Command({
             types: "public_channel", // TODO: In order to show private channels, we need the identity of the caller.
         })) as ConversationsListResponse;
         if (!response.ok) {
-            log.error(`Failed trying to fetch channels for ${teamId}.`, response);
+            log.error(`Failed trying to fetch channels for ${teamId}.`, response.error);
             res.status(HTTP_CODES.SERVER_ERROR).json({error: "Failed to fetch channels"});
             return;
         }

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -136,7 +136,7 @@ export class SlackGhost {
     public async getBotName(botId: string, client: WebClient) {
         const response = (await client.bots.info({ bot: botId})) as BotsInfoResponse;
         if (!response.ok || !response.bot.name) {
-            log.error("Failed to get bot name", response);
+            log.error("Failed to get bot name", response.error);
             return;
         }
         return response.bot.name;
@@ -144,13 +144,18 @@ export class SlackGhost {
 
     public async getBotAvatarUrl(botId: string, client: WebClient) {
         const response = (await client.bots.info({ bot: botId})) as BotsInfoResponse;
-        if (!response.ok || !response.bot.icons.image_72) {
-            log.error("Failed to get bot name", response);
+        if (!response.ok) {
+            log.error("Failed to get bot name", response.error);
             return;
         }
         const icons = response.bot.icons;
-        return icons.image_original || icons.image_1024 || icons.image_512 ||
+        const icon = icons.image_original || icons.image_1024 || icons.image_512 ||
             icons.image_192 || icons.image_72 || icons.image_48;
+        if (!icon) {
+            log.error("No suitable icon for bot");
+            return;
+        }
+        return icon;
     }
 
     public async lookupUserInfo(client: WebClient) {

--- a/src/SlackHookHandler.ts
+++ b/src/SlackHookHandler.ts
@@ -391,7 +391,7 @@ export class SlackHookHandler extends BaseSlackHandler {
         })) as ConversationsHistoryResponse;
 
         if (!response.ok || !response.messages || response.messages.length === 0) {
-            log.warn("Could not find history: " + response);
+            log.warn("Could not find history: " + response.error);
             throw Error("Could not find history");
         }
         if (response.messages.length !== 1) {


### PR DESCRIPTION
It takes up HUGE amounts of log and leaks a lot of info