### PR TITLE
Always send a 200 on an Event API request

### DIFF
--- a/changelog.d/261.bugfix
+++ b/changelog.d/261.bugfix
@@ -1,0 +1,1 @@
+Fix issue where using RTM on large deployments would trigger Slack to turn off Event subscriptions

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -66,14 +66,22 @@ export class SlackEventHandler extends BaseSlackHandler {
      * Handles a slack event request.
      * @param ISlackEventParams
      */
-    public async handle(event: ISlackEvent, teamId: string, response: EventHandlerCallback) {
+    public async handle(event: ISlackEvent, teamId: string, response: EventHandlerCallback, isEventAndUsingRtm: boolean) {
         try {
-            log.debug("Received slack event:", event, teamId);
-
-            const endTimer = this.main.startTimer("remote_request_seconds");
             // See https://api.slack.com/events-api#responding_to_events
             // We must respond within 3 seconds or it will be sent again!
             response(HTTP_OK, "OK");
+
+            if (isEventAndUsingRtm) {
+                // This is a special flag that is raised if the team is using the RTM
+                // API AND this event is from the Events API. Certain Events only come down
+                // that API, and we may have to handle those in the future. For now, all the events
+                // given below can be found on both APIs.
+                // If this flag is true, we should return early to avoid duplication.
+                return;
+            }
+            log.debug("Received slack event:", event, teamId);
+            const endTimer = this.main.startTimer("remote_request_seconds");
 
             let err: Error|null = null;
             try {

--- a/src/SlackRTMHandler.ts
+++ b/src/SlackRTMHandler.ts
@@ -127,7 +127,7 @@ export class SlackRTMHandler extends SlackEventHandler {
                         log.error("Cannot handle event, no active teamId!");
                         return;
                     }
-                    await this.handle(event, rtm.activeTeamId! , () => {});
+                    await this.handle(event, rtm.activeTeamId! , () => {}, false);
                 } catch (ex) {
                     log.error(`Failed to handle '${eventName}' event`);
                 }

--- a/src/tests/integration/SlackToMatrixTest.ts
+++ b/src/tests/integration/SlackToMatrixTest.ts
@@ -36,14 +36,32 @@ describe("SlackToMatrix", () => {
     });
 
     it("will drop slack events that have an unknown type", async () => {
+        let called = false;
         await harness.eventHandler.handle({
             type: "faketype",
             channel: "fakechannel",
             ts: "12345",
         }, "12345", (status: number, body?: string) => {
+            called = true;
             expect(status).to.equal(200);
             expect(body).to.equal("OK");
-        });
+        }, false);
         expect(harness.main.timerFinished.remote_request_seconds).to.be.equal("dropped");
+        expect(called).to.be.true;
+    });
+
+    it("will no-op slack events when using RTM API and is an Event API request", async () => {
+        let called = false;
+        await harness.eventHandler.handle({
+            type: "faketype",
+            channel: "fakechannel",
+            ts: "12345",
+        }, "12345", (status: number, body?: string) => {
+            called = true;
+            expect(status).to.equal(200);
+            expect(body).to.equal("OK");
+        }, true);
+        expect(harness.main.timerFinished.remote_request_seconds).to.be.undefined;
+        expect(called).to.be.true;
     });
 });


### PR DESCRIPTION
This PR refactors our event handling so that we correctly handle Event API requests, even if using the RTM API too. This bug came up when matrix.org switched on RTM and stopped handling Events for nearly every team. While this means that RTM has more or less taken over the matrix.org deployment (yay), it also made slack turn off our Events API subscription (boo).