### PR TITLE
Limit upload size

### DIFF
--- a/changelog.d/264.bugfix
+++ b/changelog.d/264.bugfix
@@ -1,0 +1,1 @@
+Fix issue where uploading large files will crash the bridge.

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -40,6 +40,8 @@ homeserver: # Required
   # This is usually the public url of your homeserver.
   # Optional, will use `url` by default.
   media_url: "http://my.server.here"
+  # Optional. The maximum size of a uploaded file to Matrix in bytes. No limit by default
+  # max_upload_size: 104857600
 
 # Optional
 logging:

--- a/config/slack-config-schema.yaml
+++ b/config/slack-config-schema.yaml
@@ -13,6 +13,8 @@ properties:
         type: string
       media_url:
         type: string
+      max_upload_size:
+        type: number
   tls:
     type: object
     required: ["key_file", "crt_file"]

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -99,6 +99,7 @@ export interface ISlackFile {
     url_private?: string;
     public_url_shared?: string;
     permalink?: string;
+    size: number;
 }
 
 export interface ISlackUser {

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -611,7 +611,7 @@ export class BridgedRoom {
             };
             return ghost.sendMessage(this.MatrixRoomId, matrixContent, channelId, eventTS);
         } else if (message.files) { // A message without a subtype can contain files.
-            const uploadSize = this.main.config.homeserver.max_upload_size;
+            const maxUploadSize = this.main.config.homeserver.max_upload_size;
             for (const file of message.files) {
                 if (!file.url_private) {
                     // Cannot do anything with this.
@@ -651,18 +651,16 @@ export class BridgedRoom {
                     };
                     await ghost.sendMessage(this.matrixRoomId, messageContent, channelId, eventTS);
                 } else {
-                    if (uploadSize && file.size > uploadSize) {
+                    if (maxUploadSize && file.size > maxUploadSize) {
                         const link = file.public_url_shared ? file.permalink_public : file.url_private;
-                        if (link) {
-                            log.info("File too large, sending as a link");
-                            const messageContent = {
-                                body: `${link} (${file.name})`,
-                                format: "org.matrix.custom.html",
-                                formatted_body: `<a href="${link}">${file.name}</a>`,
-                                msgtype: "m.text",
-                            };
-                            await ghost.sendMessage(this.matrixRoomId, messageContent, channelId, eventTS);
-                        }
+                        log.info("File too large, sending as a link");
+                        const messageContent = {
+                            body: `${link} (${file.name})`,
+                            format: "org.matrix.custom.html",
+                            formatted_body: `<a href="${link}">${file.name}</a>`,
+                            msgtype: "m.text",
+                        };
+                        await ghost.sendMessage(this.matrixRoomId, messageContent, channelId, eventTS);
                         continue;
                     }
                     // We also need to upload the thumbnail

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -652,7 +652,7 @@ export class BridgedRoom {
                     await ghost.sendMessage(this.matrixRoomId, messageContent, channelId, eventTS);
                 } else {
                     if (uploadSize && file.size > uploadSize) {
-                        const link = file.permalink_public || file.url_private;
+                        const link = file.public_url_shared ? file.permalink_public : file.url_private;
                         if (link) {
                             log.info("File too large, sending as a link");
                             const messageContent = {

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -611,11 +611,13 @@ export class BridgedRoom {
             };
             return ghost.sendMessage(this.MatrixRoomId, matrixContent, channelId, eventTS);
         } else if (message.files) { // A message without a subtype can contain files.
+            const uploadSize = this.main.config.homeserver.max_upload_size;
             for (const file of message.files) {
                 if (!file.url_private) {
                     // Cannot do anything with this.
                     continue;
                 }
+
                 if (file.mode === "snippet") {
                     let htmlString: string;
                     try {
@@ -648,13 +650,21 @@ export class BridgedRoom {
                         msgtype: "m.text",
                     };
                     await ghost.sendMessage(this.matrixRoomId, messageContent, channelId, eventTS);
-                    // TODO: Currently Matrix lacks a way to upload a "captioned image",
-                    //   so we just send a separate `m.image` and `m.text` message
-                    // See https://github.com/matrix-org/matrix-doc/issues/906
-                    if (message.text) {
-                        return ghost.sendText(this.matrixRoomId, message.text, channelId, eventTS);
-                    }
                 } else {
+                    if (uploadSize && file.size > uploadSize) {
+                        const link = file.permalink_public || file.url_private;
+                        if (link) {
+                            log.info("File too large, sending as a link");
+                            const messageContent = {
+                                body: `${link} (${file.name})`,
+                                format: "org.matrix.custom.html",
+                                formatted_body: `<a href="${link}">${file.name}</a>`,
+                                msgtype: "m.text",
+                            };
+                            await ghost.sendMessage(this.matrixRoomId, messageContent, channelId, eventTS);
+                        }
+                        continue;
+                    }
                     // We also need to upload the thumbnail
                     let thumbnailPromise: Promise<string> = Promise.resolve("");
                     // Slack ain't a believer in consistency.
@@ -678,13 +688,13 @@ export class BridgedRoom {
                         channelId,
                         eventTS,
                     );
-                    // TODO: Currently Matrix lacks a way to upload a "captioned image",
-                    //   so we just send a separate `m.image` and `m.text` message
-                    // See https://github.com/matrix-org/matrix-doc/issues/906
-                    if (message.text) {
-                        return ghost.sendText(this.matrixRoomId, message.text, channelId, eventTS);
-                    }
                 }
+            }
+            // TODO: Currently Matrix lacks a way to upload a "captioned image",
+            //   so we just send a separate `m.image` and `m.text` message
+            // See https://github.com/matrix-org/matrix-doc/issues/906
+            if (message.text) {
+                return ghost.sendText(this.matrixRoomId, message.text, channelId, eventTS);
             }
         } else {
             log.warn(`Ignoring message with subtype: ${subtype}`);

--- a/src/IConfig.ts
+++ b/src/IConfig.ts
@@ -34,6 +34,7 @@ export interface IConfig {
         url: string;
         server_name: string;
         media_url?: string;
+        max_upload_size?: number;
     };
 
     tls?: {


### PR DESCRIPTION
This fixes an issue where uploading large files will crash the bridge. The fix here is to provide a URL as a fallback if the file exceeds the configured limit.