### PR TITLE
Fix issue where migrator cannot get the team token

### DIFF
--- a/changelog.d/267.bugfix
+++ b/changelog.d/267.bugfix
@@ -1,0 +1,1 @@
+Fix migrator bug where it would not find an access token

--- a/src/scripts/migrateToPostgres.ts
+++ b/src/scripts/migrateToPostgres.ts
@@ -107,7 +107,8 @@ export async function migrateFromNedb(nedb: NedbDatastore, targetDs: Datastore) 
     const preTeamMigrations = () => Promise.all(allRooms.map(async (room, i) => {
         // This is an old format remote
         // tslint:disable-next-line: no-any
-        const at = (room.remote as any).access_token;
+        const remote = (room.remote as any);
+        const at = remote.slack_bot_token || remote.access_token;
         if (!at) {
             return;
         }


### PR DESCRIPTION
This fixed an issue where some entries would store the bot token under a different key to `access_token`. 