### PR TITLE
Fix webhooks not being able to send messages to Matrix

### DIFF
--- a/changelog.d/269.bugfix
+++ b/changelog.d/269.bugfix
@@ -1,0 +1,1 @@
+Fix issue where Slack webhooks would not be able to send messages to Matrix.

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -298,7 +298,7 @@ export class Main {
         return `@${localpart}:${this.config.homeserver.server_name}`;
     }
 
-    public async getGhostForSlackMessage(message: any, teamId: string): Promise<SlackGhost> {
+    public async getGhostForSlackMessage(message: any, teamId?: string): Promise<SlackGhost> {
         // Slack ghost IDs need to be constructed from user IDs, not usernames,
         // because users can change their names
         // TODO if the team_domain is changed, we will recreate all users.
@@ -309,7 +309,7 @@ export class Main {
         return this.getGhostForSlack(message.user_id, teamDomain, teamId);
     }
 
-    public async getGhostForSlack(slackUserId: string, teamDomain: string, teamId: string): Promise<SlackGhost> {
+    public async getGhostForSlack(slackUserId: string, teamDomain: string, teamId?: string): Promise<SlackGhost> {
         const userId = this.getUserId(
             slackUserId.toUpperCase(),
             teamDomain,
@@ -331,8 +331,8 @@ export class Main {
             log.debug("Creating new ghost for", userId);
             ghost = new SlackGhost(
                 this,
-                slackUserId.toUpperCase(),
-                teamId.toUpperCase(),
+                slackUserId,
+                teamId,
                 userId,
                 intent,
             );

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -62,11 +62,15 @@ export class SlackGhost {
     constructor(
         private main: Main,
         public readonly slackId: string,
-        public readonly teamId: string,
+        public readonly teamId: string|undefined,
         public readonly userId: string,
         public readonly intent?: Intent,
         private displayName?: string,
         private avatarUrl?: string) {
+        this.slackId = slackId.toUpperCase();
+        if (teamId) {
+            this.teamId = teamId.toUpperCase();
+        }
     }
 
     public toEntry(): UserEntry {

--- a/src/datastore/Models.ts
+++ b/src/datastore/Models.ts
@@ -37,7 +37,7 @@ export interface UserEntry {
     display_name: string;
     avatar_url: string;
     slack_id: string;
-    team_id: string;
+    team_id?: string;
 }
 
 export interface EventEntry {

--- a/src/tests/integration/SharedDatastoreTests.ts
+++ b/src/tests/integration/SharedDatastoreTests.ts
@@ -34,8 +34,8 @@ export const doDatastoreTests = (ds: () => Datastore, roomsAfterEach: () => void
                     display_name: "A displayname",
                     avatar_url: "Some avatar",
                     id: "someid1",
-                    slack_id: "foobar",
-                    team_id: "barbaz",
+                    slack_id: "FOOBAR",
+                    team_id: "BARBAZ",
                 }, null),
             );
             const userEntry = await ds().getUser("someid1");
@@ -43,8 +43,8 @@ export const doDatastoreTests = (ds: () => Datastore, roomsAfterEach: () => void
                 display_name: "A displayname",
                 avatar_url: "Some avatar",
                 id: "someid1",
-                slack_id: "foobar",
-                team_id: "barbaz",
+                slack_id: "FOOBAR",
+                team_id: "BARBAZ",
             });
         });
 
@@ -53,8 +53,8 @@ export const doDatastoreTests = (ds: () => Datastore, roomsAfterEach: () => void
                 display_name: "A displayname",
                 avatar_url: "Some avatar",
                 id: "someid3",
-                slack_id: "foobar",
-                team_id: "barbaz",
+                slack_id: "FOOBAR",
+                team_id: "BARBAZ",
             }, null);
             await ds().upsertUser(user);
             (user as any).displayName = "A changed displayname";
@@ -64,8 +64,8 @@ export const doDatastoreTests = (ds: () => Datastore, roomsAfterEach: () => void
                 display_name: "A changed displayname",
                 avatar_url: "Some avatar",
                 id: "someid3",
-                slack_id: "foobar",
-                team_id: "barbaz",
+                slack_id: "FOOBAR",
+                team_id: "BARBAZ",
             });
         });
 


### PR DESCRIPTION
We assume here that teamId is set, where it may not be since webhooks do not have a teamId. This unbreaks bridging slack messages into Matrix by only calling toUpperCase inside the SlackGhost, if the values are given. 