### PR TITLE
Fix syntax typo for service start command

### DIFF
--- a/changelog.d/317.doc
+++ b/changelog.d/317.doc
@@ -1,0 +1,1 @@
+Fix syntax typo for service start command.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -78,7 +78,7 @@ $ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack \
 
 6. Start the actual application service:
 
-    `$ npm start -c config.yaml -p $MATRIX_PORT`
+    `$ npm start -- -c config.yaml -p $MATRIX_PORT`
    or with docker:
    
     `$ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack`


### PR DESCRIPTION
Running the start application command included in the getting_started docs just shows the help window for the npm start command. This PR adds the flag that makes the command work correctly. A small typo, but important for users without much experience with npm.