### PR TITLE
Allow a trailing colon followed by a space for mentions

### DIFF
--- a/changelog.d/320.bugfix
+++ b/changelog.d/320.bugfix
@@ -1,0 +1,1 @@
+Mentions will now work if followed by a colon and a space

--- a/src/substitutions.ts
+++ b/src/substitutions.ts
@@ -150,7 +150,7 @@ class Substitutions {
                 if (ghost && ghost.slackId) {
                     // We need to replace the user's displayname with the slack mention, but we need to
                     // ensure to do it only on whitespace wrapped strings.
-                    const userRegex = new RegExp(`(?<=^|\\s)${escapeStringRegexp(user.text)}(?=$|\\s)`, "g");
+                    const userRegex = new RegExp(`(?<=^|\\s)${escapeStringRegexp(user.text)}(?=$|\\s|: )`, "g");
                     body = body.replace(userRegex, `<@${ghost.slackId}>`);
                 }
             }


### PR DESCRIPTION
Why a colon followed by a space, because Riot does mentions this way. Why do we care about the space? So we don't match the localparts of userIds.