### PR TITLE
Membership Sync Slack <-> Matrix

### DIFF
--- a/changelog.d/332.feature
+++ b/changelog.d/332.feature
@@ -1,0 +1,1 @@
+Sync Slack membership changes to Matrix

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -58,6 +58,7 @@ export interface ISlackEventMessageAttachment {
 }
 
 export interface ISlackMessageEvent extends ISlackEvent {
+    inviter?: string;
     item?: {
         type: string;
         channel: string;

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -361,7 +361,7 @@ export class BridgedRoom {
 
     public async onMatrixMessage(message: any) {
         const puppetedClient = await this.main.clientFactory.getClientForUser(this.SlackTeamId!, message.user_id);
-        if (!this.slackWebhookUri && !this.botClient) { return false; }
+        if (!this.slackWebhookUri && !this.botClient && !puppetedClient) { return false; }
         const slackClient = puppetedClient || this.botClient;
         const user = this.main.getOrCreateMatrixUser(message.user_id);
         message = await this.stripMatrixReplyFallback(message);
@@ -455,6 +455,91 @@ export class BridgedRoom {
             await this.main.datastore.upsertEvent(parentStoredEvent);
         }
         return true;
+    }
+
+    public async onSlackUserLeft(slackId: string) {
+        const ghost = await this.main.getGhostForSlack(slackId, undefined, this.slackTeamId);
+        await ghost.intent.leave(this.matrixRoomId);
+    }
+
+    public async onSlackUserJoin(slackId: string, wasInvitedBy?: string) {
+        // There are different flows for this:
+        // 1 - Slack user invites slack user
+        // 2 - Slack user invites matrix user
+        // 3 - Matrix user invites slack user
+        // 4 - Matrix user invites matrix user
+        // 5 - Slack user has joined
+        // 6 - Matrix user has joined
+
+        const recipientPuppet = await this.main.clientFactory.getClientForSlackUser(this.slackTeamId!, slackId);
+        const recipientGhost = await this.main.getGhostForSlack(slackId, undefined, this.slackTeamId);
+
+        const senderPuppet = await this.main.clientFactory.getClientForSlackUser(this.slackTeamId!, slackId);
+        const senderGhost = await this.main.getGhostForSlack(slackId, undefined, this.slackTeamId);
+        const mxid = await this.main.datastore.getPuppetMatrixUserBySlackId(this.slackTeamId!, slackId);
+
+        if (!wasInvitedBy) {
+            if (!recipientPuppet) {
+                log.debug(`S-> ${slackId} joined ${this.SlackChannelId}`);
+                // 5
+                await recipientGhost.intent.join(this.matrixRoomId);
+            } else {
+                log.debug(`M-> ${slackId} joined ${this.SlackChannelId}`);
+                // 6
+                await this.main.botIntent.invite(this.matrixRoomId, mxid);
+            }
+            return;
+        }
+
+        if (!recipientPuppet && !senderPuppet) {
+            log.debug(`S->S ${slackId} was invited by ${wasInvitedBy}`);
+            // 1
+            await senderGhost.intent.invite(this.matrixRoomId, recipientGhost.userId);
+            await recipientGhost.intent.join(this.matrixRoomId, recipientGhost.userId);
+        } else if (recipientPuppet) {
+            // 2 & 4
+            log.debug(`S|M->M${mxid} was invited by ${wasInvitedBy}`);
+            await senderGhost.intent.invite(this.matrixRoomId, mxid);
+        } else if (senderPuppet && !recipientPuppet) {
+            log.debug(`M->S ${slackId} was invited by ${wasInvitedBy}`);
+            // 3
+            await recipientGhost.intent.join(this.matrixRoomId);
+            // No-op
+        }
+    }
+
+    public async onMatrixLeave(userId: string) {
+        log.info(`Leaving ${userId} from ${this.SlackChannelId}`);
+        const puppetedClient = await this.main.clientFactory.getClientForUser(this.SlackTeamId!, userId);
+        if (!puppetedClient) {
+            log.debug("No client");
+            return;
+        }
+        await puppetedClient.conversations.leave({ channel: this.SlackChannelId! });
+    }
+
+    public async onMatrixJoin(userId: string) {
+        log.info(`Joining ${userId} to ${this.SlackChannelId}`);
+        const puppetedClient = await this.main.clientFactory.getClientForUser(this.SlackTeamId!, userId);
+        if (!puppetedClient) {
+            log.debug("No client");
+            return;
+        }
+        await puppetedClient.conversations.join({ channel: this.SlackChannelId! });
+    }
+
+    public async onMatrixInvite(inviter: string, invitee: string) {
+        const puppetedClient = await this.main.clientFactory.getClientForUser(this.SlackTeamId!, inviter);
+        if (!puppetedClient) {
+            log.debug("No client");
+            return;
+        }
+        const ghost = await this.main.getExistingSlackGhost(invitee);
+        if (!ghost) {
+            log.debug("No ghost");
+            return;
+        }
+        await puppetedClient.conversations.invite({channel: this.slackChannelId!, users: ghost.slackId });
     }
 
     public async onSlackMessage(message: ISlackMessageEvent, content?: Buffer) {

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1120,7 +1120,7 @@ export class Main {
 
     public async getNullGhostDisplayName(channel: string, userId: string): Promise<string> {
         const room = this.rooms.getBySlackChannelId(channel);
-        const nullGhost = new SlackGhost(this, userId, room!.SlackTeamId!, userId);
+        const nullGhost = new SlackGhost(this, userId, room!.SlackTeamId!, userId, undefined);
         if (!room || !room.SlackClient) {
             return userId;
         }

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -184,6 +184,12 @@ export class SlackEventHandler extends BaseSlackHandler {
         // Only count received messages that aren't self-reflections
         this.main.incCounter("received_messages", {side: "remote"});
 
+        if (event.type === "channel_join") {
+            await room.onSlackUserJoin(event.user!, event.inviter!);
+        } else if (event.type === "channel_leave") {
+            await room.onSlackUserLeft(event.user!);
+        }
+
         const msg = Object.assign({}, event, {
             channel_id: event.channel,
             team_domain: team.domain || team.id,

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -65,7 +65,7 @@ export class SlackGhost {
         public readonly slackId: string,
         public readonly teamId: string|undefined,
         public readonly userId: string,
-        public readonly intent?: Intent,
+        public readonly intent: Intent,
         private displayName?: string,
         private avatarHash?: string) {
         this.slackId = slackId.toUpperCase();

--- a/src/tests/utils/fakeMain.ts
+++ b/src/tests/utils/fakeMain.ts
@@ -59,10 +59,10 @@ export class FakeMain {
 
     public async getExistingSlackGhost(userId: string) {
         if (userId === "@stranger:localhost") {
-            return new SlackGhost(this as unknown as Main, "12345", undefined, "@stranger:localhost");
+            return new SlackGhost(this as unknown as Main, "12345", undefined, "@stranger:localhost", undefined);
         }
         if (userId === "@thing:localhost") {
-            return new SlackGhost(this as unknown as Main, "54321", undefined, "@thing:localhost");
+            return new SlackGhost(this as unknown as Main, "54321", undefined, "@thing:localhost", undefined);
         }
         return null;
     }


### PR DESCRIPTION
This does several fancy things:

- Handles all the various ways the bridge needs to handle slack joins (it's surprisingly complex!).
- Handles leaves
- Handles invites
- Handles joining a matrix user's puppet upon joining a channel.