### PR TITLE
Typed rooms

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -42,6 +42,7 @@ import PQueue from "p-queue";
 import { UserAdminRoom } from "./rooms/UserAdminRoom";
 import { TeamSyncer } from "./TeamSyncer";
 import { AppService, AppServiceRegistration } from "matrix-appservice";
+import { fromEntry } from "./rooms/Rooms";
 
 const log = Logging.get("Main");
 
@@ -903,12 +904,16 @@ export class Main {
         if (!slackClient && !entry.remote.webhook_uri) { // Do not warn if this is a webhook.
             log.warn(`${entry.remote.name} ${entry.remote.id} does not have a WebClient and will not be able to issue slack requests`);
         }
-        const room = BridgedRoom.fromEntry(this, entry, teamEntry, slackClient || undefined);
+        const room = fromEntry(this, entry, teamEntry, slackClient || undefined);
         await this.addBridgedRoom(room);
         room.MatrixRoomActive = activeRoom;
         if (!room.IsPrivate && activeRoom) {
             // Only public rooms can be tracked.
-            this.stateStorage.trackRoom(entry.matrix_id);
+            try {
+                await this.stateStorage.trackRoom(entry.matrix_id);
+            } catch (ex) {
+                this.stateStorage.untrackRoom(entry.matrix_id);
+            }
         }
     }
 

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -59,7 +59,8 @@ export class SlackEventHandler extends BaseSlackHandler {
      * to events in order to handle them.
      */
     protected static SUPPORTED_EVENTS: string[] = ["message", "reaction_added", "reaction_removed",
-    "team_domain_change", "channel_rename", "user_typing"];
+                                                   "team_domain_change", "channel_rename", "user_typing",
+                                                   "channel_created", "channel_deleted", "user_change", "team_join"];
     constructor(main: Main) {
         super(main);
     }

--- a/src/SlackRTMHandler.ts
+++ b/src/SlackRTMHandler.ts
@@ -230,6 +230,7 @@ export class SlackRTMHandler extends SlackEventHandler {
             await this.main.datastore.upsertRoom(room);
         } else if (!room) {
             log.warn(`No room found for ${event.channel} and not sure how to create one`);
+            return;
         }
         return this.handleMessageEvent(event, puppet.teamId);
     }

--- a/src/rooms/DMRoom.ts
+++ b/src/rooms/DMRoom.ts
@@ -1,0 +1,50 @@
+import { BridgedRoom, IBridgedRoomOpts } from "../BridgedRoom";
+import { Main } from "../Main";
+import { TeamEntry } from "../datastore/Models";
+import { WebClient } from "@slack/web-api";
+import { ISlackMessageEvent } from "../BaseSlackHandler";
+import { ConversationsMembersResponse } from "../SlackResponses";
+import { Logging } from "matrix-appservice-bridge";
+
+const log = Logging.get("DMRoom");
+
+/**
+ * The DM room class is used to implement custom logic for
+ * "im" and "mpim" rooms.
+ */
+export class DMRoom extends BridgedRoom {
+    constructor(main: Main, opts: IBridgedRoomOpts, team: TeamEntry, botClient: WebClient) {
+        super(main, opts, team, botClient);
+    }
+
+    public async onSlackMessage(message: ISlackMessageEvent, content?: Buffer) {
+        await super.onSlackMessage(message, content);
+
+        // Check if the recipient is joined to the room.
+        const cli = await this.main.clientFactory.getClientForUser(this.SlackTeamId!, this.puppetOwner!);
+        if (!cli) {
+            return;
+        }
+
+        const expectedSlackMembers = (await cli.conversations.members({ channel: this.SlackChannelId! }) as ConversationsMembersResponse).members;
+        const expectedMatrixMembers = (await Promise.all(expectedSlackMembers.map(
+            (slackId) => this.main.datastore.getPuppetMatrixUserBySlackId(this.SlackTeamId!, slackId),
+        )));
+
+        const members = await this.main.listAllUsers(this.MatrixRoomId);
+        const intent = await this.getIntentForRoom();
+
+        try {
+            await Promise.all(
+                expectedMatrixMembers.filter((s) => s !== null && !members.includes(s)).map(
+                    (member) => {
+                        log.info(`Reinviting ${member} to the room`);
+                        return intent.invite(this.MatrixRoomId, member);
+                    },
+                ),
+            );
+        } catch (ex) {
+            log.warn("Failed to reinvite user to the room:", ex);
+        }
+    }
+}

--- a/src/rooms/Rooms.ts
+++ b/src/rooms/Rooms.ts
@@ -1,0 +1,30 @@
+import { Main } from "../Main";
+import { RoomEntry, TeamEntry } from "../datastore/Models";
+import { WebClient } from "@slack/web-api";
+import { DMRoom } from "./DMRoom";
+import { BridgedRoom } from "../BridgedRoom";
+
+export function fromEntry(main: Main, entry: RoomEntry, team?: TeamEntry, botClient?: WebClient) {
+    const slackType = entry.remote.slack_type;
+    const opts = {
+        inbound_id: entry.remote_id,
+        matrix_room_id: entry.matrix_id,
+        slack_channel_id: entry.remote.id,
+        slack_channel_name: entry.remote.name,
+        slack_team_id: entry.remote.slack_team_id,
+        slack_webhook_uri: entry.remote.webhook_uri,
+        puppet_owner: entry.remote.puppet_owner,
+        is_private: entry.remote.slack_private,
+        slack_type: entry.remote.slack_type,
+    };
+    if (slackType === "im" || slackType === "mpim") {
+        if (!team) {
+            throw Error("'team' is undefined, but required for DM rooms");
+        }
+        if (!botClient) {
+            throw Error("'botClient' is undefined, but required for DM rooms");
+        }
+        return new DMRoom(main, opts, team, botClient);
+    }
+    return new BridgedRoom(main, opts, team, botClient);
+}


### PR DESCRIPTION
This kicks off support for allowing custom behaviours depending on the "type" of room. For PMs, we want to do different things to channels and so a `DMRoom` class exists for this. In the future, I want to dramatically trim back some of the code in `BridgedRoom` to be part of a channel class.