### PR TITLE
add proxy options for RTM connection

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -74,3 +74,12 @@ matrix_admin_room: "!aBcDeF:matrix.org"
 # Enable metrics reporting on http://0.0.0.0:bridgePort/metrics which can be scraped by prometheus
 # Optional
 enable_metrics: true
+
+# proxy for slack RTM connection
+proxy:
+    enable: false
+    host: ""
+    port: 8118
+    protocol: "http"
+    headers: {}
+

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "matrix-appservice-bridge": "^1.9.0",
     "minimist": "^1.2",
     "nedb": "^1.8.0",
+    "https-proxy-agent": "^3.0.1",
     "node-emoji": "^1.10.0",
     "p-queue": "^6.1.1",
     "pg-promise": "^9.0.2",

--- a/src/IConfig.ts
+++ b/src/IConfig.ts
@@ -76,4 +76,14 @@ export interface IConfig {
     };
 
     dbdir: string;
+
+    proxy: {
+        enable: boolean;
+        host: string;
+        port: number;
+        protocol: string;
+        headers?: {
+            [key: string]: string
+        };
+    }
 }

--- a/src/tests/integration/HttpTests.ts
+++ b/src/tests/integration/HttpTests.ts
@@ -43,6 +43,13 @@ function constructHarness() {
         rtm: {
             enable: true,
         },
+        proxy: {
+            enable: true,
+            host: "proxyHost",
+            port: 8118,
+            protocol: "http",
+            headers: {"foo": "bar"}
+        },
     }, reg);
     (main as any).bridge.getBot = () => ({
        getJoinedRooms: () => Promise.resolve([]),


### PR DESCRIPTION
This PR add a proxy option for connection to slack with RTM.

ref:
  - slack doc: https://slack.dev/node-slack-sdk/rtm-api#proxy-requests-with-a-custom-agent
  - https-proxy-agent: https://www.npmjs.com/package/https-proxy-agent  

usage:
```yaml
proxy:
    enable: enable
    host: "example-proxy.host"
    port: 8118
    protocol: "http"
    headers: {
        "foo": "bar"
    }
```

I am not a professional TypeScript programmer, so any advices will be appreciated ! 