### PR TITLE
Allow URL prefixes on webhook urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ node_modules
 
 # typescript
 lib
-
+tsconfig.tsbuildinfo

--- a/changelog.d/339.bugfix
+++ b/changelog.d/339.bugfix
@@ -1,0 +1,1 @@
+Allow webhook/oauth/event requests with prefixes.

--- a/src/tests/unit/SlackHookHandlerTest.ts
+++ b/src/tests/unit/SlackHookHandlerTest.ts
@@ -33,21 +33,21 @@ describe("SlackHookHandler", () => {
     });
     it("getUrlParts should accept a id followed by a path and parameters", () => {
         const { inboundId, path } = SlackHookHandler.getUrlParts(
-            "0337a838-2fec-4b79-8186-8111f781/authorize?code=123123123.213123&state=123123-asdasd-21"
+            "0337a838-2fec-4b79-8186-8111f781/authorize?code=123123123.213123&state=123123-asdasd-21",
         );
         expect(inboundId).to.equal("0337a838-2fec-4b79-8186-8111f781");
         expect(path).to.equal("authorize?code=123123123.213123&state=123123-asdasd-21");
     });
     it("getUrlParts should accept a id with a prefix", () => {
         const { inboundId, path } = SlackHookHandler.getUrlParts(
-            "/my/slack/prefix/0337a838-2fec-4b79-8186-8111f781/authorize?code=123123123.213123&state=123123-asdasd-21"
+            "/my/slack/prefix/0337a838-2fec-4b79-8186-8111f781/authorize?code=123123123.213123&state=123123-asdasd-21",
         );
         expect(inboundId).to.equal("0337a838-2fec-4b79-8186-8111f781");
         expect(path).to.equal("authorize?code=123123123.213123&state=123123-asdasd-21");
     });
     it("getUrlParts should accept a id with a prefix without a slash", () => {
         const { inboundId, path } = SlackHookHandler.getUrlParts(
-            "my/slack/prefix/0337a838-2fec-4b79-8186-8111f781/authorize?code=123123123.213123&state=123123-asdasd-21"
+            "my/slack/prefix/0337a838-2fec-4b79-8186-8111f781/authorize?code=123123123.213123&state=123123-asdasd-21",
         );
         expect(inboundId).to.equal("0337a838-2fec-4b79-8186-8111f781");
         expect(path).to.equal("authorize?code=123123123.213123&state=123123-asdasd-21");

--- a/src/tests/unit/SlackHookHandlerTest.ts
+++ b/src/tests/unit/SlackHookHandlerTest.ts
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// tslint:disable: no-unused-expression no-any
+
+import { BridgedRoom } from "../../BridgedRoom";
+import { SlackHookHandler } from "../../SlackHookHandler";
+import { expect } from "chai";
+
+describe("SlackHookHandler", () => {
+    it("getUrlParts should accept a id without a path", () => {
+        const { inboundId, path } = SlackHookHandler.getUrlParts("0337a838-2fec-4b79-8186-8111f781");
+        expect(inboundId).to.equal("0337a838-2fec-4b79-8186-8111f781");
+        expect(path).to.equal("post");
+    });
+    it("getUrlParts should accept a id followed by a path", () => {
+        const { inboundId, path } = SlackHookHandler.getUrlParts("0337a838-2fec-4b79-8186-8111f781/authorize");
+        expect(inboundId).to.equal("0337a838-2fec-4b79-8186-8111f781");
+        expect(path).to.equal("authorize");
+    });
+    it("getUrlParts should accept a id followed by a path and parameters", () => {
+        const { inboundId, path } = SlackHookHandler.getUrlParts(
+            "0337a838-2fec-4b79-8186-8111f781/authorize?code=123123123.213123&state=123123-asdasd-21"
+        );
+        expect(inboundId).to.equal("0337a838-2fec-4b79-8186-8111f781");
+        expect(path).to.equal("authorize?code=123123123.213123&state=123123-asdasd-21");
+    });
+    it("getUrlParts should accept a id with a prefix", () => {
+        const { inboundId, path } = SlackHookHandler.getUrlParts(
+            "/my/slack/prefix/0337a838-2fec-4b79-8186-8111f781/authorize?code=123123123.213123&state=123123-asdasd-21"
+        );
+        expect(inboundId).to.equal("0337a838-2fec-4b79-8186-8111f781");
+        expect(path).to.equal("authorize?code=123123123.213123&state=123123-asdasd-21");
+    });
+    it("getUrlParts should accept a id with a prefix without a slash", () => {
+        const { inboundId, path } = SlackHookHandler.getUrlParts(
+            "my/slack/prefix/0337a838-2fec-4b79-8186-8111f781/authorize?code=123123123.213123&state=123123-asdasd-21"
+        );
+        expect(inboundId).to.equal("0337a838-2fec-4b79-8186-8111f781");
+        expect(path).to.equal("authorize?code=123123123.213123&state=123123-asdasd-21");
+    });
+    it("getUrlParts should throw on an empty string", () => {
+        expect(() => {
+            SlackHookHandler.getUrlParts("");
+        }).to.throw;
+    });
+    it("getUrlParts should throw on an /", () => {
+        expect(() => {
+            SlackHookHandler.getUrlParts("/");
+        }).to.throw;
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "./lib",
     "rootDir": "./src",
     "strict": true,
+    "incremental": true,
     "noImplicitAny": false,
   },
   "include": [


### PR DESCRIPTION
This is to fix modular slack bridge routing issues. Tests come free.