### PR TITLE
Ensure team token is still valid

### DIFF
--- a/changelog.d/355.bugfix
+++ b/changelog.d/355.bugfix
@@ -1,0 +1,1 @@
+Fix issue where slack bot actions may fail (such as listing channels). Also increase the number of channels returned when provisioning

--- a/src/SlackClientFactory.ts
+++ b/src/SlackClientFactory.ts
@@ -222,7 +222,6 @@ export class SlackClientFactory {
             log.debug("Created new team client for", teamInfo.team.name);
             return { slackClient, team: teamInfo.team, auth, user };
         } catch (ex) {
-            console.log(ex);
             throw Error("Could not create team client: " + ex.data.error);
         }
     }

--- a/src/tests/utils/slackTestApi.ts
+++ b/src/tests/utils/slackTestApi.ts
@@ -42,7 +42,6 @@ export class SlackTestApi {
         let body = "";
         req.on("data", (chunk) => body += chunk);
         req.on("end", () => {
-            console.log(req.method, req.url);
             const query = qs.decode(body);
             if (req.method === "POST" && req.url === "/team.info") {
                 this.onTeamInfo(query, res);
@@ -112,8 +111,8 @@ export class SlackTestApi {
                     is_bot: true,
                     profile: {
                         bot_id: "12345",
-                    }
-                }
+                    },
+                },
             } as UsersInfoResponse));
         } else {
             res.write(JSON.stringify({

--- a/src/tests/utils/slackTestApi.ts
+++ b/src/tests/utils/slackTestApi.ts
@@ -1,7 +1,8 @@
 import { WebClientOptions, LogLevel } from "@slack/web-api";
 import { createServer, Server, IncomingMessage, ServerResponse } from "http";
 import { promisify } from "util";
-import { TeamInfoResponse } from "../../SlackResponses";
+import { TeamInfoResponse, AuthTestResponse, UsersInfoResponse } from "../../SlackResponses";
+import * as qs from "querystring";
 
 export class SlackTestApi {
     private server: Server;
@@ -41,8 +42,14 @@ export class SlackTestApi {
         let body = "";
         req.on("data", (chunk) => body += chunk);
         req.on("end", () => {
+            console.log(req.method, req.url);
+            const query = qs.decode(body);
             if (req.method === "POST" && req.url === "/team.info") {
-                this.onTeamInfo(req, body, res);
+                this.onTeamInfo(query, res);
+            } else if (req.method === "POST" && req.url === "/auth.test") {
+                this.onAuthTest(query, res);
+            } else if (req.method === "POST" && req.url === "/users.info") {
+                this.onUsersInfo(query, res);
             } else {
                 res.writeHead(404);
                 res.write("Nada");
@@ -51,18 +58,63 @@ export class SlackTestApi {
         });
     }
 
-    private onTeamInfo(req: IncomingMessage, body: string, res: ServerResponse) {
-        const token = body.substr("token=".length);
+    private onAuthTest(query: qs.ParsedUrlQuery, res: ServerResponse) {
         // Slack usually uses 200s for everything.
         res.writeHead(200, "OK", {"Content-Type": "application/json"});
-        if (this.allowAuthFor.has(token)) {
+        if (this.allowAuthFor.has(query.token as string)) {
+            res.write(JSON.stringify({
+                ok: true,
+                url: "https://subarachnoid.slack.com/",
+                team: "Subarachnoid Workspace",
+                user: "bot",
+                team_id: "T0G9PQBBK",
+                user_id: "W23456789",
+            } as AuthTestResponse));
+        } else {
             res.write(JSON.stringify({
                 ok: false,
+                error: "invalid_auth",
+            }));
+        }
+    }
+
+    private onTeamInfo(query: qs.ParsedUrlQuery, res: ServerResponse) {
+        // Slack usually uses 200s for everything.
+        res.writeHead(200, "OK", {"Content-Type": "application/json"});
+        if (this.allowAuthFor.has(query.token as string)) {
+            res.write(JSON.stringify({
+                ok: true,
                 team: {
                     id: "foo",
                     domain: "foobar",
                 },
             } as TeamInfoResponse));
+        } else {
+            res.write(JSON.stringify({
+                ok: false,
+                error: "Team not allowed for test",
+            }));
+        }
+    }
+
+    private onUsersInfo(query: qs.ParsedUrlQuery, res: ServerResponse) {
+        // Slack usually uses 200s for everything.
+        res.writeHead(200, "OK", {"Content-Type": "application/json"});
+        if (this.allowAuthFor.has(query.token as string)) {
+            res.write(JSON.stringify({
+                ok: true,
+                user: {
+                    id: "W012A3CDE",
+                    team_id: "T012AB3C4",
+                    name: "alice",
+                    deleted: false,
+                    real_name: "Alice",
+                    is_bot: true,
+                    profile: {
+                        bot_id: "12345",
+                    }
+                }
+            } as UsersInfoResponse));
         } else {
             res.write(JSON.stringify({
                 ok: false,


### PR DESCRIPTION
We need to regularly check that the access token cached is still valid, as a validation step. This should hopefully fix things like #354. We've also cheekily cranked up the number of channels returned from a `channels` call on the provisioner.