### PR TITLE
Clarify path of config.yml in the docs

### DIFF
--- a/changelog.d/364.doc
+++ b/changelog.d/364.doc
@@ -1,0 +1,1 @@
+Change NPM instructions to use the path config/config.yaml

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -78,7 +78,7 @@ $ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack \
 
 6. Start the actual application service:
 
-    `$ npm start -- -c config.yaml -p $MATRIX_PORT`
+    `$ npm start -- -c config/config.yaml -p $MATRIX_PORT`
    or with docker:
    
     `$ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack`

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -56,7 +56,7 @@ ever stuck, you can post a question in the
    firewalls appropriately. This ports will be notated as `$MATRIX_PORT` in
    the remaining instructions.
 
-3. Create a `config.yaml` file for global configuration. There is a sample
+3. Create a `config/config.yaml` file for global configuration. There is a sample
    one to begin with in `config/config.sample.yaml`. You should copy and
    edit as appropriate. The required and optional values are flagged in the config.
 


### PR DESCRIPTION
I got confused by the path of step 3 including the `config/` folder, but `config.yaml` not including the folder name.
When they both include the folder name, it's easier to tell where the new file should be placed.