### PR TITLE
Correct database name to slack_bridge

### DIFF
--- a/changelog.d/365.doc
+++ b/changelog.d/365.doc
@@ -1,0 +1,1 @@
+Correct database name in a code example to slack_bridge

--- a/docs/datastores.md
+++ b/docs/datastores.md
@@ -13,7 +13,7 @@ permission on the bridge:
 ```sql
 CREATE DATABASE slack_bridge;
 CREATE USER slackbridge_user WITH PASSWORD 'somethingverysecret';
-GRANT ALL PRIVILEGES ON DATABASE "slack" to slackbridge_user;
+GRANT ALL PRIVILEGES ON DATABASE "slack_bridge" to slackbridge_user;
 ```
 
 You should then update the config with details about the new database.

--- a/docs/datastores.md
+++ b/docs/datastores.md
@@ -13,7 +13,7 @@ permission on the bridge:
 ```sql
 CREATE DATABASE slack_bridge;
 CREATE USER slackbridge_user WITH PASSWORD 'somethingverysecret';
-GRANT ALL PRIVILEGES ON DATABASE "slack_bridge" to slackbridge_user;
+GRANT ALL PRIVILEGES ON DATABASE slack_bridge to slackbridge_user;
 ```
 
 You should then update the config with details about the new database.


### PR DESCRIPTION
In the third line of this SQL code `slack` is used for the database name instead of `slack_bridge`.
Keeping it all the same removes the need to adapt the code sample.