### PR TITLE
Include server name in the Matrix users regex

### DIFF
--- a/changelog.d/368.bugfix
+++ b/changelog.d/368.bugfix
@@ -1,0 +1,1 @@
+Include server name in the Matrix users regex

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,7 +30,7 @@ const cli = new Cli({
         reg.setHomeserverToken(AppServiceRegistration.generateToken());
         reg.setAppServiceToken(AppServiceRegistration.generateToken());
         reg.setSenderLocalpart("slackbot");
-        reg.addRegexPattern("users", `@${config.username_prefix}.*`, true);
+        reg.addRegexPattern("users", `@${config.username_prefix}.*:${config.homeserver.server_name}`, true);
         callback(reg);
     },
     run(port: number, config: IConfig, registration: any) {


### PR DESCRIPTION
Fixes #360 by including the server name in the regex that determines which users the bridge controls.