### PR TITLE
Correct ISlackEvent.user type

### DIFF
--- a/changelog.d/374.misc
+++ b/changelog.d/374.misc
@@ -1,0 +1,1 @@
+Correct ISlackEvent.user type; remove unused declarations

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -60,7 +60,7 @@ export interface ISlackEventMessageAttachment {
 
 export interface ISlackMessageEvent extends ISlackEvent {
     team_domain?: string;
-    user: string;
+    user?: string;
     user_id: string;
     inviter?: string;
     item?: {

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -49,7 +49,6 @@ export interface ISlackEvent {
     type: string;
     channel: string;
     ts: string;
-    user?: string;
     bot_id?: string;
     team_domain?: string;
     user_id: string;
@@ -61,6 +60,7 @@ export interface ISlackEventMessageAttachment {
 
 export interface ISlackMessageEvent extends ISlackEvent {
     team_domain?: string;
+    user: string;
     user_id: string;
     inviter?: string;
     item?: {

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -20,33 +20,43 @@ import { Main } from "./Main";
 import { Logging } from "matrix-appservice-bridge";
 const log = Logging.get("SlackEventHandler");
 
+/**
+ * https://api.slack.com/events/channel_rename
+ */
 interface ISlackEventChannelRename extends ISlackEvent {
-    // https://api.slack.com/events/channel_rename
     id: string;
     name: string;
     created: number;
 }
 
+/**
+ * https://api.slack.com/events/team_domain_change
+ */
 interface ISlackEventTeamDomainChange extends ISlackEvent {
-    // https://api.slack.com/events/team_domain_change
     url: string;
     domain: string;
 }
 
+/**
+ * https://api.slack.com/events/reaction_added
+ */
 interface ISlackEventReaction extends ISlackEvent {
-    // https://api.slack.com/events/reaction_added
     reaction: string;
     item: ISlackMessage;
     user: string;
 }
 
+/**
+ * https://api.slack.com/events/user_typing
+ */
 interface ISlackEventUserTyping extends ISlackEvent {
-    // https://api.slack.com/events/user_typing
     user: string;
 }
 
+/**
+ * https://api.slack.com/events/channel_created
+ */
 interface ISlackEventChannelCreated {
-    // https://api.slack.com/events/channel_created
     type: string;
     channel: {
         id: string;
@@ -56,6 +66,10 @@ interface ISlackEventChannelCreated {
     };
 }
 
+/**
+ * A container for multiple event types which we only handle,
+ * if team_sync is enabled.
+ */
 interface ISlackTeamSyncEvent extends ISlackEvent {
     user?: ISlackUser;
 }

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -197,9 +197,9 @@ export class SlackEventHandler extends BaseSlackHandler {
         this.main.incCounter("received_messages", {side: "remote"});
 
         if (event.type === "channel_join") {
-            await room.onSlackUserJoin(event.user, event.inviter!);
+            await room.onSlackUserJoin(event.user!, event.inviter!);
         } else if (event.type === "channel_leave") {
-            await room.onSlackUserLeft(event.user);
+            await room.onSlackUserLeft(event.user!);
         }
 
         const msg = Object.assign({}, event, {

--- a/src/SlackRTMHandler.ts
+++ b/src/SlackRTMHandler.ts
@@ -13,8 +13,9 @@ const log = Logging.get("SlackRTMHandler");
 
 const LOG_TEAM_LEN = 12;
 /**
- * This handler connects to Slack using the RTM API (events API, but websockets).
+ * This handler connects to Slack using the Real Time Messaging (RTM) API.
  * It reuses the SlackEventHandler to handle events.
+ * The RTM API works like the Events API, but uses websockets. https://api.slack.com/rtm
  */
 export class SlackRTMHandler extends SlackEventHandler {
     private rtmTeamClients: Map<string, Promise<RTMClient>>; // team -> client

--- a/src/substitutions.ts
+++ b/src/substitutions.ts
@@ -18,8 +18,6 @@ import { Logging } from "matrix-appservice-bridge";
 import * as emoji from "node-emoji";
 import { Main } from "./Main";
 import { ISlackFile } from "./BaseSlackHandler";
-import { UserEntry } from "./datastore/Models";
-import { ConversationsMembersResponse } from "./SlackResponses";
 import * as escapeStringRegexp from "escape-string-regexp";
 
 const log = Logging.get("substitutions");
@@ -33,10 +31,6 @@ const PILL_REGEX = /<a href="https:\/\/matrix\.to\/#\/(#|@|\+)([^"]+)">([^<]+)<\
  */
 export function getFallbackForMissingEmoji(name): string {
     return `:${name}:`;
-}
-
-interface IDisplayMap {
-    [name: string]: string;
 }
 
 interface PillItem {
@@ -321,10 +315,10 @@ export default substitutions;
 /**
  * Replace plain text form of @displayname mentions with the slack mention syntax.
  *
- * @param {Main} main the toplevel main instance
- * @param {String} string The string to perform replacements on.
- * @param {String} room_id The room the message was sent in.
- * @return {String} The string with replacements performed.
+ * @param main the toplevel main instance
+ * @param string The string to perform replacements on.
+ * @param room_id The room the message was sent in.
+ * @return The string with replacements performed.
  */
 async function plainTextSlackMentions(main: Main, body: string, teamId: string) {
     let users = await main.datastore.getAllUsersForTeam(teamId);


### PR DESCRIPTION
Fixes #373

Depending on the event type `user` is:
 * undefined,
 * an id string or
 * an ISlackUser (e.g. for the type `user_change`).