### PR TITLE
Remove ts-lint-disable where no-any is obsolete or does matter

### DIFF
--- a/changelog.d/375.misc
+++ b/changelog.d/375.misc
@@ -1,0 +1,1 @@
+Enable code linting for no-any where it does matter

--- a/src/AdminCommands.ts
+++ b/src/AdminCommands.ts
@@ -52,7 +52,6 @@ export class AdminCommands {
                     return yg.options(cmd.options);
                 }
             // TODO: Fix typing
-            // tslint:disable-next-line: no-any
             }) as any, cmd.handler.bind(cmd));
         });
     }

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -102,7 +102,6 @@ export class Main {
     private slackHookHandler?: SlackHookHandler;
     private slackRtm?: SlackRTMHandler;
 
-    // tslint:disable-next-line: no-any
     private metrics: PrometheusMetrics;
 
     private adminCommands = new AdminCommands(this);

--- a/src/Provisioning.ts
+++ b/src/Provisioning.ts
@@ -39,7 +39,6 @@ function command(...params: Param[]) {
 }
 
 export class Provisioner {
-    // tslint:disable-next-line: no-any
     constructor(private main: Main, private bridge: any) { }
 
     public addAppServicePath() {
@@ -195,7 +194,6 @@ export class Provisioner {
         log.debug(`${userId} requested their puppeted accounts`);
         const allPuppets = await this.main.datastore.getPuppetedUsers();
         const accts = allPuppets.filter((p) => p.matrixId === userId);
-        // tslint:disable-next-line: no-any
         const accounts = await Promise.all(accts.map(async (acct: any) => {
             delete acct.token;
             const client = await this.main.clientFactory.getClientForUser(acct.teamId, acct.matrixId);

--- a/src/SlackHookHandler.ts
+++ b/src/SlackHookHandler.ts
@@ -137,7 +137,6 @@ export class SlackHookHandler extends BaseSlackHandler {
         const isUsingRtm = this.main.teamIsUsingRtm(eventPayload.team_id.toUpperCase());
         this.eventHandler.handle(
             // The event can take many forms.
-            // tslint:disable-next-line: no-any
             eventPayload.event as any,
             eventPayload.team_id,
             eventsResponse,
@@ -385,7 +384,6 @@ export class SlackHookHandler extends BaseSlackHandler {
      *     formatted as a float.
      */
     private async lookupMessage(channelID: string, timestamp: string, client: WebClient): Promise<{
-        // tslint:disable-next-line: no-any
         message: ISlackMessageEvent, content: Buffer|undefined}> {
         // Look up all messages at the exact timestamp we received.
         // This has microsecond granularity, so should return the message we want.

--- a/src/SlackRTMHandler.ts
+++ b/src/SlackRTMHandler.ts
@@ -62,7 +62,6 @@ export class SlackRTMHandler extends SlackEventHandler {
         log.debug(`Started RTM client for user ${key}`, team);
     }
 
-    // tslint:disable-next-line: no-any
     private async handleRtmMessage(puppetEntry: PuppetEntry, slackClient: WebClient, teamInfo: ISlackTeam, e: any) {
         const chanInfo = (await slackClient!.conversations.info({channel: e.channel})) as ConversationsInfoResponse;
         // is_private is unreliably set.

--- a/src/tests/integration/AdminCommandTest.ts
+++ b/src/tests/integration/AdminCommandTest.ts
@@ -18,8 +18,6 @@ import { expect } from "chai";
 import { constructHarness } from "../utils/harness";
 import { FakeDatastore } from "../utils/fakeDatastore";
 
-// tslint:disable: no-unused-expression no-any
-
 let harness: { main: Main };
 
 describe("AdminCommandTest", () => {
@@ -44,6 +42,7 @@ describe("AdminCommandTest", () => {
             },
             type: "m.room.message",
         });
+        // tslint:disable-next-line: no-unused-expression
         expect(called).to.be.false;
     });
 

--- a/src/tests/unit/SlackRoomStoreTest.ts
+++ b/src/tests/unit/SlackRoomStoreTest.ts
@@ -19,7 +19,6 @@ describe("SlackRoomStore", () => {
             matrix_room_id: "!foo:bar",
             inbound_id: "foo",
         });
-        // tslint:disable-next-line: no-any
         roomStore.upsertRoom(room);
 
         expect(roomStore.getByInboundId("foo")).to.equal(room);
@@ -37,7 +36,6 @@ describe("SlackRoomStore", () => {
             inbound_id: "foo",
             slack_channel_id: "bar",
         });
-        // tslint:disable-next-line: no-any
         roomStore.upsertRoom(room);
 
         expect(roomStore.getByInboundId("foo")).to.equal(room);
@@ -56,7 +54,6 @@ describe("SlackRoomStore", () => {
             inbound_id: "foo",
             slack_channel_id: "bar",
         });
-        // tslint:disable-next-line: no-any
         roomStore.upsertRoom(room);
         roomStore.upsertRoom(room);
         roomStore.upsertRoom(room);
@@ -103,7 +100,6 @@ describe("SlackRoomStore", () => {
             inbound_id: "foo",
             slack_channel_id: "bar",
         });
-        // tslint:disable-next-line: no-any
         roomStore.upsertRoom(room);
         room.SlackChannelId = "baz";
         roomStore.upsertRoom(room);
@@ -123,7 +119,6 @@ describe("SlackRoomStore", () => {
             inbound_id: "foo",
             slack_channel_id: "bar",
         });
-        // tslint:disable-next-line: no-any
         roomStore.upsertRoom(room);
         room.InboundId = "baz";
         roomStore.upsertRoom(room);
@@ -142,7 +137,6 @@ describe("SlackRoomStore", () => {
             matrix_room_id: "!foo:bar",
             inbound_id: "foo",
         });
-        // tslint:disable-next-line: no-any
         roomStore.upsertRoom(room);
         roomStore.removeRoom(room);
         expect(roomStore.getByInboundId("foo")).to.be.undefined;
@@ -160,7 +154,6 @@ describe("SlackRoomStore", () => {
             inbound_id: "foo",
             slack_channel_id: "bar",
         });
-        // tslint:disable-next-line: no-any
         roomStore.upsertRoom(room);
         roomStore.removeRoom(room);
         expect(roomStore.getByInboundId("foo")).to.be.undefined;


### PR DESCRIPTION
There are some obsolete `ts-lint-disabled no-any` lines in the code and some where we'll probably want to replace any with something different in the long-term.

`no-any` is currently set to warning.

I've not touched any `event: any` lines as those are basically unpredictable responses from an API.