### PR TITLE
Upgrade quick-lru dependency

### DIFF
--- a/changelog.d/383.misc
+++ b/changelog.d/383.misc
@@ -1,0 +1,1 @@
+Upgrade quick-lru dependency (requires NodeJS >=10)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2262,9 +2262,9 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.0.0.tgz",
+      "integrity": "sha512-iNjBLSxM3byM7z8a1MB/Oa+AAeopX4NqKEj/ykgKRi1R4AFXNINR4DSjyjDzXzjqjN9+OBQGfK5w5CAnCtV7jg=="
     },
     "randomstring": {
       "version": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node-emoji": "^1.10.0",
     "p-queue": "^6.3.0",
     "pg-promise": "^9.0.2",
-    "quick-lru": "^4.0.1",
+    "quick-lru": "^5.0.0",
     "randomstring": "^1",
     "request-promise-native": "^1.0.8",
     "uuid": "^7.0.2",


### PR DESCRIPTION
quick-lru 5 requires NodeJS >=10.

I think this is ok, because we only test this bridge against NodeJS 10 and NodeJS 12.
If we were still supporting NodeJS 8, we should run our tests for that version.