### PR TITLE
Add Launch config for VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch on port 9999",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/lib/app.js",
+            "preLaunchTask": "npm: build",
+            "args": ["-c", "config/config.yaml", "-p", "9999"],
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ]
+        }
+    ]
+}

--- a/changelog.d/384.misc
+++ b/changelog.d/384.misc
@@ -1,0 +1,1 @@
+Add Launch config for VS Code and enable SourceMaps

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "incremental": true,
     "noImplicitAny": false,
     "experimentalDecorators": true,
+    "sourceMap": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Adds a Launch config for VS Code, allowing to quickly start and inspect the bridge inside of VS Code.

* Not sure, if we want to have this in the repo, as it is specific to one editor.
* I locally had picked port 9999. It's unfortunate that this is hard-coded in this PR, but I didn't want to make it flexible before I know there is an interest in this PR at all.
* SourceMaps need to be enabled for breakpoints to work.

![Screenshot_2020-03-26_14-47-29](https://user-images.githubusercontent.com/10872136/77654020-c035e800-6f70-11ea-8cbd-09e01f0c54c1.png)
