### PR TITLE
Add error and debug logs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ slack-registration.yaml
 # Logs
 logs
 *.log
+/debug.log.*
+/error.log.*
 
 # Runtime data
 pids

--- a/changelog.d/385.misc
+++ b/changelog.d/385.misc
@@ -1,0 +1,1 @@
+Add error and debug logs to .gitignore


### PR DESCRIPTION
Is there a command line option to place them in the ignored `logs` folder?
I find it irritating that the default path for logs isn't listed in `.gitignore`.