### PR TITLE
Remove chalk as a direct dependency

### DIFF
--- a/changelog.d/386.misc
+++ b/changelog.d/386.misc
@@ -1,0 +1,1 @@
+Remove chalk as a direct dependency

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@slack/web-api": "^5.8.0",
     "Slackdown": "Half-Shot/slackdown#efd8934a3d9c3bf0064c0b217c5cf6b62ee697e4",
     "chai": "^4.2.0",
-    "chalk": "^2.4.1",
     "escape-string-regexp": "^2.0.0",
     "matrix-appservice": "^0.4.1",
     "matrix-appservice-bridge": "^1.11.1",


### PR DESCRIPTION
I can't find [chalk](https://www.npmjs.com/package/chalk) directly used anywhere in our project – only dependencies seem to used it.