### PR TITLE
Upgrade dependency pg-promise 10

### DIFF
--- a/changelog.d/387.misc
+++ b/changelog.d/387.misc
@@ -1,0 +1,1 @@
+Upgrade dependency pg-promise 10, which requires PostgreSQL 11

--- a/package-lock.json
+++ b/package-lock.json
@@ -397,9 +397,9 @@
       }
     },
     "assert-options": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.5.0.tgz",
-      "integrity": "sha512-Vmvi35I4B+8K9pNQpoAzGZiJaM8nN+8fZAR4d4mo0MDyP4RRox/JYmdH97xvLrUSI6kubopwmbWjLu+bUSTn/Q=="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.6.1.tgz",
+      "integrity": "sha512-jH2pNULN0t3uFLb7Fh0SAuMo/Ei5yWiRirvLez2g+sd16d0xKl+DGdGkD6sqkrZTnCZK5lWRjUa4X3sxHQkg9g=="
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -1575,11 +1575,6 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
-    "manakin": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/manakin/-/manakin-0.5.2.tgz",
-      "integrity": "sha512-pfDSB7QYoVg0Io4KMV9hhPoXpj6p0uBscgtyUSKCOFZe8bqgbpStfgnKIbF/ulnr6U3ICu4OqdyxAqBgOhZwBQ=="
-    },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -2114,14 +2109,15 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.12.1.tgz",
-      "integrity": "sha512-l1UuyfEvoswYfcUe6k+JaxiN+5vkOgYcVSbSuw3FvdLqDbaoa2RJo1zfJKfPsSYPFVERd4GHvX3s2PjG1asSDA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.18.2.tgz",
+      "integrity": "sha512-Mvt0dGYMwvEADNKy5PMQGlzPudKcKKzJds/VbOeZJpb6f/pI3mmoXX0JksPgI3l3JPP/2Apq7F36O63J7mgveA==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
         "pg-connection-string": "0.1.3",
-        "pg-pool": "^2.0.4",
+        "pg-packet-stream": "^1.1.0",
+        "pg-pool": "^2.0.10",
         "pg-types": "^2.1.0",
         "pgpass": "1.x",
         "semver": "4.3.2"
@@ -2145,25 +2141,29 @@
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-minify": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.5.0.tgz",
-      "integrity": "sha512-qcH0oUJl6ayAlX8rIO6dGFIbtbMKw0NoMDfXCOpRFUryPJZKh7yj8hsWfGfBgeHW1zkpe8etLo3AdeU7nBPqmw=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.5.2.tgz",
+      "integrity": "sha512-uZn/gXkGmO5JBdopxNLSpFMS1lXr+KJqynI8Di1Qyr8ZVXt67ruh+XNfzLMVdLzYv+MQRdNYQdVwWPSs0qM7xQ=="
+    },
+    "pg-packet-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
+      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
     },
     "pg-pool": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.7.tgz",
-      "integrity": "sha512-UiJyO5B9zZpu32GSlP0tXy8J2NsJ9EFGFfz5v6PSbdz/1hBLX1rNiiy5+mAm5iJJYwfCv4A0EBcQLGWwjbpzZw=="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
+      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg=="
     },
     "pg-promise": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-9.1.1.tgz",
-      "integrity": "sha512-2HxXdy7t4QW94vNRTlvHpJQpXWmPjx4wWLnapr0kZPCZ7kcAyBlo14giHdkApCxGonhgDwc/Ebn+iRGi5Hk+Ww==",
+      "version": "10.4.4",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-10.4.4.tgz",
+      "integrity": "sha512-N2NsOgKxrnNPwP0Q609ZmxmAZEo2TQ26SzSvlbZWQb8vteqUhOPpU/pHi9DGatJrPcXNoyr4xjRw42CNfEBg/w==",
       "requires": {
-        "assert-options": "0.5.0",
-        "manakin": "0.5.2",
-        "pg": "7.12.1",
-        "pg-minify": "1.5.0",
-        "spex": "3.0.0"
+        "assert-options": "0.6.1",
+        "pg": "7.18.2",
+        "pg-minify": "1.5.2",
+        "spex": "3.0.1"
       }
     },
     "pg-types": {
@@ -2501,9 +2501,9 @@
       }
     },
     "spex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spex/-/spex-3.0.0.tgz",
-      "integrity": "sha512-JoMfgbrJcEPn53JCLkSNH1o7fZ9rzkb24UKEt5LTcsp0YsaN+yxtb5MEmibbMRltj9CdXDNGitPrYi11JY2hog=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spex/-/spex-3.0.1.tgz",
+      "integrity": "sha512-priWZUrXBmVPHTOmtUeS7gZzCOUwRK87OHJw5K8bTC6MLOq93mQocx+vWccNyKPT2EY+goZvKGguGn2lx8TBDA=="
     },
     "split": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "nedb": "^1.8.0",
     "node-emoji": "^1.10.0",
     "p-queue": "^6.3.0",
-    "pg-promise": "^9.0.2",
+    "pg-promise": "^10.4.4",
     "quick-lru": "^5.0.0",
     "randomstring": "^1",
     "request-promise-native": "^1.0.8",


### PR DESCRIPTION
List of breaking changes:
https://github.com/vitaly-t/pg-promise/releases/tag/10.0.0

* Requires PostgreSQL 11 or later, which is the only version we're testing against anyway.
* Changes to the usage of `proc` and `func` which we are not using.