### PR TITLE
Fix PostgreSQL errors when a metric activity is recorded twice

### DIFF
--- a/changelog.d/393.misc
+++ b/changelog.d/393.misc
@@ -1,1 +1,1 @@
-Silence PostgreSQL errors when a metric activity is recorded twice
+Fix PostgreSQL errors when a metric activity is recorded twice

--- a/changelog.d/393.misc
+++ b/changelog.d/393.misc
@@ -1,0 +1,1 @@
+Silence PostgreSQL errors when a metric activity is recorded twice

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -299,7 +299,7 @@ export class PgDatastore implements Datastore {
         await this.postgresDb.none(
             "INSERT INTO metrics_activities (user_id, room_id, date) " +
             "VALUES(${userId}, ${roomId}, ${date}) " +
-            "ON CONFLICT cons_activities_unique DO NOTHING;", {
+            "ON CONFLICT ON CONSTRAINT cons_activities_unique DO NOTHING;", {
             date: `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`,
             roomId: room.toEntry().id,
             userId,

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -296,19 +296,14 @@ export class PgDatastore implements Datastore {
         date = date || new Date();
         const userId = (user instanceof SlackGhost) ? user.toEntry().id : user.userId;
 
-        try {
-            await this.postgresDb.none("INSERT INTO metrics_activities (user_id, room_id, date) VALUES(${userId}, ${roomId}, ${date})", {
-                date: `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`,
-                roomId: room.toEntry().id,
-                userId,
-            });
-        } catch (error) {
-            if (error.message === "duplicate key value violates unique constraint \"cons_activities_unique\"") {
-                // The user already had an action in this room today. That's no problem.
-                return;
-            }
-            throw error;
-        }
+        await this.postgresDb.none(
+            "INSERT INTO metrics_activities (user_id, room_id, date) " +
+            "VALUES(${userId}, ${roomId}, ${date}) " +
+            "ON CONFLICT cons_activities_unique DO NOTHING;", {
+            date: `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`,
+            roomId: room.toEntry().id,
+            userId,
+        });
     }
 
     public async getActiveRoomsPerTeam(activityThreshholdInDays = 2, historyLengthInDays = 30): Promise<Map<string, Map<RoomType, number>>> {

--- a/src/tests/integration/SharedDatastoreTests.ts
+++ b/src/tests/integration/SharedDatastoreTests.ts
@@ -277,4 +277,28 @@ export const doDatastoreTests = (ds: () => Datastore, roomsAfterEach: () => void
             });
         });
     });
+
+    describe("metrics", () => {
+        it("should not throw when an activity is upserted twice", async () => {
+            const user = SlackGhost.fromEntry(null as any, {
+                display_name: "A displayname",
+                avatar_url: "Some avatar",
+                id: "someid1",
+                slack_id: "FOOBAR",
+                team_id: "BARBAZ",
+            }, null);
+            const room = new BridgedRoom({} as any, {
+                inbound_id: "a_remote_id",
+                matrix_room_id: "a_matrix_id",
+                slack_channel_id: "a_channel_id",
+                slack_channel_name: "a_channel_name",
+                slack_team_id: "a_team_id",
+                slack_webhook_uri: "a_webhook_uri",
+                puppet_owner: undefined,
+            }, {} as any);
+            const date = new Date();
+            await ds().upsertActivityMetrics(user, room, date);
+            await ds().upsertActivityMetrics(user, room, date);
+        });
+    });
 };


### PR DESCRIPTION
Every time a user posts in a room they have already posted in on that day, the bridge outputs an error, if the metrics are enabled:

```
Apr-16 11:24:55.729 ERROR BridgedRoom Error storing activity metrics error: duplicate key value violates unique constraint "cons_activities_unique"
    at Connection.parseE (/home/jaller94/Git/Matrix/matrix-appservice-slack/node_modules/pg/lib/connection.js:614:13)
    at Connection.parseMessage (/home/jaller94/Git/Matrix/matrix-appservice-slack/node_modules/pg/lib/connection.js:413:19)
    at Socket.<anonymous> (/home/jaller94/Git/Matrix/matrix-appservice-slack/node_modules/pg/lib/connection.js:129:22)
    at Socket.emit (events.js:315:20)
    at addChunk (_stream_readable.js:297:12)
    at readableAddChunk (_stream_readable.js:273:9)
    at Socket.Readable.push (_stream_readable.js:214:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:186:23) {
  name: 'error',
  length: 307,
  severity: 'ERROR',
  code: '23505',
  detail: 'Key (user_id, room_id, date)=(@jaller94:localhost, INTEG-Q9cv0tMFJgpsU7pC38KZ1xyR6zBlK07W, 2020-03-16) already exists.',
  hint: undefined,
  position: undefined,
  internalPosition: undefined,
  internalQuery: undefined,
  where: undefined,
  schema: 'public',
  table: 'metrics_activities',
  column: undefined,
  dataType: undefined,
  constraint: 'cons_activities_unique',
  file: 'nbtinsert.c',
  line: '570',
  routine: '_bt_check_unique'
}
```