### PR TITLE
Add configuration to limit teams and rooms counts

### DIFF
--- a/changelog.d/397.feature
+++ b/changelog.d/397.feature
@@ -1,0 +1,1 @@
+Add ability to limit the number of teams and rooms via the config

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -102,3 +102,9 @@ team_sync:
 
 provisioning:
   enabled: true
+  # Should the bridge allow public rooms to be bridged
+  require_public_room: true
+  limits:
+    room_count: 20
+    team_count: 1
+

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -102,7 +102,7 @@ team_sync:
 
 provisioning:
   enabled: true
-  # Should the bridge allow public rooms to be bridged
+  # Should the bridge deny users bridging channels to private rooms.
   require_public_room: true
   limits:
     room_count: 20

--- a/config/slack-config-schema.yaml
+++ b/config/slack-config-schema.yaml
@@ -104,3 +104,18 @@ properties:
           properties:
             enabled:
               type: boolean
+  provisioning:
+    type: object
+    required: ["enabled"]
+    properties:
+      enabled:
+        type: boolean
+      require_public_room:
+        type: boolean
+      enabled:
+        type: object
+        properties:
+          room_count:
+            type: number
+          team_count:
+            type: number

--- a/config/slack-config-schema.yaml
+++ b/config/slack-config-schema.yaml
@@ -112,7 +112,7 @@ properties:
         type: boolean
       require_public_room:
         type: boolean
-      enabled:
+      limits:
         type: object
         properties:
           room_count:

--- a/src/IConfig.ts
+++ b/src/IConfig.ts
@@ -82,7 +82,7 @@ export interface IConfig {
 
     provisioning?: {
         enable: boolean;
-        require_public_room: boolean;
+        require_public_room?: boolean;
         limits?: {
             team_count?: number;
             room_count?: number;

--- a/src/IConfig.ts
+++ b/src/IConfig.ts
@@ -84,4 +84,9 @@ export interface IConfig {
         enable: boolean;
         auth_callbck: string;
     };
+
+    limits?: {
+        team_count?: number;
+        room_count?: number;
+    }
 }

--- a/src/IConfig.ts
+++ b/src/IConfig.ts
@@ -82,11 +82,10 @@ export interface IConfig {
 
     provisioning?: {
         enable: boolean;
-        auth_callbck: string;
+        require_public_room: boolean;
+        limits?: {
+            team_count?: number;
+            room_count?: number;
+        }
     };
-
-    limits?: {
-        team_count?: number;
-        room_count?: number;
-    }
 }

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1121,7 +1121,7 @@ export class Main {
         return accounts.find((acct) => acct.team_id === teamId);
     }
 
-    public async willReachTeamLimit(teamId: string) {
+    public async willExceedTeamLimit(teamId: string) {
         // First, check if we are limited
         if (!this.config.limits?.team_count) {
             return false;

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1121,6 +1121,15 @@ export class Main {
         return accounts.find((acct) => acct.team_id === teamId);
     }
 
+    public async willReachTeamLimit(teamId: string) {
+        // First, check if we are limited
+        if (!this.config.limits?.team_count) {
+            return false;
+        }
+        const idSet = new Set((await this.datastore.getAllTeams()).map((t) => t.id));
+        return idSet.add(teamId).size > this.config.limits?.team_count;
+    }
+
     public async killBridge() {
         log.info("Killing bridge");
         if (this.metricsCollectorInterval) {

--- a/src/Provisioning.ts
+++ b/src/Provisioning.ts
@@ -79,8 +79,14 @@ export class Provisioner {
         }
     }
 
-    private async userIsAllowedAction(actionVerb: "link"|"unlink"|"puppet") {
-        // Hit an endpoint, and wait for a response.
+    private async reachedRoomLimit() {
+        if (!this.main.config.limits?.room_count) {
+            // No limit applied
+            return false;
+        }
+        const currentCount = await this.main.datastore.getRoomCount();
+        return (currentCount >= this.main.config.limits?.room_count);
+    }
 
     }
 

--- a/src/Provisioning.ts
+++ b/src/Provisioning.ts
@@ -101,7 +101,7 @@ export class Provisioner {
             } : null,
             team_limit: hasTeamLimit ? {
                 quota: this.main.config.provisioning?.limits?.team_count,
-                current: await this.main.clientFactory.teamClientCount,
+                current: this.main.clientFactory.teamClientCount,
             } : null,
         });
     }

--- a/src/Provisioning.ts
+++ b/src/Provisioning.ts
@@ -227,13 +227,6 @@ export class Provisioner {
         res.json({ accounts });
     }
 
-    @command("user_id", "team_id")
-    private async removeaccount(_, res, userId, teamId) {
-        log.debug(`${userId} is removing their account on ${teamId}`);
-        await this.main.clientFactory.removeClient(userId, teamId);
-        res.json({ });
-    }
-
     @command("matrix_room_id", "user_id")
     private async getlink(req, res, matrixRoomId, userId) {
         const room = this.main.rooms.getByMatrixRoomId(matrixRoomId);

--- a/src/SlackClientFactory.ts
+++ b/src/SlackClientFactory.ts
@@ -196,7 +196,7 @@ export class SlackClientFactory {
         return res !== null ? res.client : null;
     }
 
-    private async createTeamClient(token: string) {
+    public async createTeamClient(token: string) {
         const opts = this.config.slack_client_opts ? this.config.slack_client_opts : undefined;
         const slackClient = new WebClient(token, {
             logger: {

--- a/src/SlackClientFactory.ts
+++ b/src/SlackClientFactory.ts
@@ -60,6 +60,10 @@ export class SlackClientFactory {
         }
     }
 
+    public get teamClientCount() {
+        return this.teamClients.size;
+    }
+
     /**
      * Gets a WebClient for a given teamId. If one has already been
      * created, the cached client is returned.

--- a/src/SlackHookHandler.ts
+++ b/src/SlackHookHandler.ts
@@ -379,10 +379,10 @@ export class SlackHookHandler extends BaseSlackHandler {
             log.error("Error during handling of an oauth token:", err);
             return {
                 code: 403,
-                // Not using templaes to avoid newline awfulness.
+                // Not using templates to avoid newline awfulness.
                 // tslint:disable-next-line: prefer-template
                 html: "<h2>Integration Failed</h2>\n" +
-                `<p>Unfortunately your ${room ? "channel integration" : "account" } did not go as expected...</p>`,
+                `<p>Unfortunately, your ${room ? "channel integration" : "account" } did not go as expected...</p>`,
             };
         }
         return {

--- a/src/SlackHookHandler.ts
+++ b/src/SlackHookHandler.ts
@@ -342,7 +342,7 @@ export class SlackHookHandler extends BaseSlackHandler {
                 // XXX: We no longer support setting tokens for webhooks
             } else if (user) { // New event api
                 // Ensure that we can support another team.
-                if (await this.main.willReachTeamLimit(response.team_id)) {
+                if (await this.main.willExceedTeamLimit(response.team_id)) {
                     log.warn(`User ${response.user_id} tried to add a new team ${response.team_id} but the team limit was reached`);
                     try {
                         const tempClient = await this.main.clientFactory.createTeamClient(response.access_token);

--- a/src/SlackHookHandler.ts
+++ b/src/SlackHookHandler.ts
@@ -352,7 +352,7 @@ export class SlackHookHandler extends BaseSlackHandler {
                     }
                     return {
                         code: 403,
-                        // Not using templaes to avoid newline awfulness.
+                        // Not using templates to avoid newline awfulness.
                         // tslint:disable-next-line: prefer-template
                         html: "<h2>Integration Failed</h2>\n" +
                         `<p>You have reached the limit of Slack teams that can be bridged to Matrix. Please contact your admin.</p>`,

--- a/src/datastore/Models.ts
+++ b/src/datastore/Models.ts
@@ -133,4 +133,9 @@ export interface Datastore {
      * @param date The date of the action (defaults to the current date)
      */
     upsertActivityMetrics(user: MatrixUser | SlackGhost, room: BridgedRoom, date?: Date): Promise<void>;
+
+    /**
+     * Get the number of connected rooms on this instance.
+     */
+    getRoomCount(): Promise<number>;
 }

--- a/src/datastore/NedbDatastore.ts
+++ b/src/datastore/NedbDatastore.ts
@@ -244,4 +244,8 @@ export class NedbDatastore implements Datastore {
         // no-op; activity metrics are not implemented for NeDB
         return;
     }
+
+    public async getRoomCount(): Promise<number> {
+        return (await this.getAllRooms()).length;
+    }
 }

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -353,7 +353,7 @@ export class PgDatastore implements Datastore {
     }
 
     public async getRoomCount(): Promise<number> {
-        return Number.parseInt((await this.postgresDb.one("SELECT COUNT(*) FROM rooms")).count);
+        return Number.parseInt((await this.postgresDb.one("SELECT COUNT(*) FROM rooms")).count, 10);
     }
 
     private async updateSchemaVersion(version: number) {

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -352,6 +352,10 @@ export class PgDatastore implements Datastore {
         return usersByTeamAndRemote;
     }
 
+    public async getRoomCount(): Promise<number> {
+        return (await this.postgresDb.one("SELECT COUNT(*) FROM rooms")).count;
+    }
+
     private async updateSchemaVersion(version: number) {
         log.debug(`updateSchemaVersion: ${version}`);
         await this.postgresDb.none("UPDATE schema SET version = ${version};", {version});

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -353,7 +353,7 @@ export class PgDatastore implements Datastore {
     }
 
     public async getRoomCount(): Promise<number> {
-        return (await this.postgresDb.one("SELECT COUNT(*) FROM rooms")).count;
+        return Number.parseInt((await this.postgresDb.one("SELECT COUNT(*) FROM rooms")).count);
     }
 
     private async updateSchemaVersion(version: number) {

--- a/src/tests/utils/fakeDatastore.ts
+++ b/src/tests/utils/fakeDatastore.ts
@@ -124,4 +124,8 @@ export class FakeDatastore implements Datastore {
     public async upsertActivityMetrics(user: MatrixUser | SlackGhost, room: BridgedRoom, date?: Date): Promise<void> {
         return;
     }
+
+    public async getRoomCount() {
+        return 0;
+    }
 }


### PR DESCRIPTION
~~This is still missing functionality to handle the removal of team clients~~ Punting to https://github.com/matrix-org/matrix-appservice-slack/issues/399

This PR does 4 things:
- It limits the number of bridged rooms that can be created by config.
- It limits the number of teams that can be connected.
- It exposes a flag for whether the configured instance allows private rooms to be bridged to channels.
- It exposes these limits in a config endpoint.