### PR TITLE
Disallow bridging to channels that are already bridged

### DIFF
--- a/changelog.d/401.feature
+++ b/changelog.d/401.feature
@@ -1,0 +1,1 @@
+Check if a channel is linked to another room, and unauthorize the link if so.

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -957,7 +957,12 @@ export class Main {
         let teamId: string = opts.team_id!;
 
         const matrixRoomId = opts.matrix_room_id;
+        const existingChannel = opts.slack_channel_id ? this.rooms.getBySlackChannelId(opts.slack_channel_id) : null;
         const existingRoom = this.rooms.getByMatrixRoomId(matrixRoomId);
+
+        if (existingChannel) {
+            throw Error("Channel is already bridged! Unbridge the channel first.");
+        }
 
         if (!opts.team_id && !opts.slack_bot_token) {
             if (!opts.slack_webhook_uri) {


### PR DESCRIPTION
(CC: @jryans)

If a channel is bridged to a room, ensure that it won't be bridged somewhere else without first being removed from the old room.