### PR TITLE
Allow bridging of private channels via the provisioner

### DIFF
--- a/changelog.d/403.bugfix
+++ b/changelog.d/403.bugfix
@@ -1,0 +1,1 @@
+Allow bridging to private channels via the provisioner

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -104,6 +104,8 @@ provisioning:
   enabled: true
   # Should the bridge deny users bridging channels to private rooms.
   require_public_room: true
+  # Should the bridge allow usesr to bridge private channels.
+  allow_private_channels: true
   limits:
     room_count: 20
     team_count: 1

--- a/config/slack-config-schema.yaml
+++ b/config/slack-config-schema.yaml
@@ -112,6 +112,8 @@ properties:
         type: boolean
       require_public_room:
         type: boolean
+      allow_private_channels:
+        type: boolean
       limits:
         type: object
         properties:

--- a/src/IConfig.ts
+++ b/src/IConfig.ts
@@ -83,6 +83,7 @@ export interface IConfig {
     provisioning?: {
         enable: boolean;
         require_public_room?: boolean;
+        allow_private_channels?: boolean;
         limits?: {
             team_count?: number;
             room_count?: number;

--- a/src/Provisioning.ts
+++ b/src/Provisioning.ts
@@ -89,8 +89,9 @@ export class Provisioner {
 
     private async determineSlackIdForRequest(matrixUserId, teamId) {
         const matrixUser = await this.main.datastore.getMatrixUser(matrixUserId);
-        if (matrixUser === null) {
-            throw Error('No users found');
+        if (!matrixUser) {
+            // No Slack user entry found for MXID
+            return null;
         }
         const accounts: {[userId: string]: {team_id: string}} = matrixUser.get("accounts");
         for (const [key, value] of Object.entries(accounts)) {
@@ -175,6 +176,7 @@ export class Provisioner {
         const cli = await this.main.clientFactory.getTeamClient(teamId);
         try {
             let types = "public_channel";
+            // Unless we *explicity* set this to false, allow it.
             if (this.main.config.provisioning?.allow_private_channels !== false) {
                 types = `public_channel,private_channel`;
             }

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -47,7 +47,7 @@ export class PgDatastore implements Datastore {
         });
     }
 
-    public async getUser(id: string): Promise<UserEntry | null> {
+    public async getUser(id: string): Promise<UserEntry|null> {
         const dbEntry = await this.postgresDb.oneOrNone("SELECT * FROM users WHERE userId = ${id}", { id });
         if (!dbEntry) {
             return null;
@@ -55,7 +55,7 @@ export class PgDatastore implements Datastore {
         return JSON.parse(dbEntry.json);
     }
 
-    public async getMatrixUser(userId: string): Promise<MatrixUser|undefined> {
+    public async getMatrixUser(userId: string): Promise<MatrixUser|null> {
         userId = new MatrixUser(userId).getId(); // Ensure ID correctness
         const userData = await this.getUser(userId);
         return userData !== null ? new MatrixUser(userId, userData) : null;


### PR DESCRIPTION
This requires us to determine the identity of the caller in order to check if they are *in* the channel. Luckily, there is an endpoint for that :)