### PR TITLE
Pin Dockerfile node version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,4 +41,4 @@ node_modules
 
 # typescript
 lib
-
+tsconfig.tsbuildinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
-FROM node:current-alpine AS BUILD
-COPY . /tmp/src
+FROM node:14-alpine AS BUILD
+COPY . /src
 
 # git is needed to install Half-Shot/slackdown
 RUN apk add git
-RUN cd /tmp/src \
-    && npm install \
-    && npm run build
+WORKDIR /src
+RUN npm install
+RUN npm run build
 
-FROM node:current-alpine
+FROM node:14-alpine
 
 VOLUME /data/ /config/
 
 COPY package.json /usr/src/app/
 COPY package-lock.json /usr/src/app/
 
-COPY --from=BUILD /tmp/src/config /usr/src/app/config
-COPY --from=BUILD /tmp/src/lib /usr/src/app/lib
+COPY --from=BUILD /src/config /usr/src/app/config
+COPY --from=BUILD /src/lib /usr/src/app/lib
 
 WORKDIR /usr/src/app
 

--- a/changelog.d/405.bugfix
+++ b/changelog.d/405.bugfix
@@ -1,0 +1,1 @@
+Fix postgress configurations failing to start when using the offical docker image.

--- a/package-lock.json
+++ b/package-lock.json
@@ -397,9 +397,9 @@
       }
     },
     "assert-options": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.6.1.tgz",
-      "integrity": "sha512-jH2pNULN0t3uFLb7Fh0SAuMo/Ei5yWiRirvLez2g+sd16d0xKl+DGdGkD6sqkrZTnCZK5lWRjUa4X3sxHQkg9g=="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.6.2.tgz",
+      "integrity": "sha512-KP9S549XptFAPGYmLRnIjQBL4/Ry8Jx5YNLQZ/l+eejqbTidBMnw4uZSAsUrzBq/lgyqDYqxcTF7cOxZb9gyEw=="
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -2103,15 +2103,15 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.18.2.tgz",
-      "integrity": "sha512-Mvt0dGYMwvEADNKy5PMQGlzPudKcKKzJds/VbOeZJpb6f/pI3mmoXX0JksPgI3l3JPP/2Apq7F36O63J7mgveA==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.0.3.tgz",
+      "integrity": "sha512-fvcNXn4o/iq4jKq15Ix/e58q3jPSmzOp6/8C3CaHoSR/bsxdg+1FXfDRePdtE/zBb3++TytvOrS1hNef3WC/Kg==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
         "pg-connection-string": "0.1.3",
-        "pg-packet-stream": "^1.1.0",
-        "pg-pool": "^2.0.10",
+        "pg-pool": "^3.1.1",
+        "pg-protocol": "^1.2.2",
         "pg-types": "^2.1.0",
         "pgpass": "1.x",
         "semver": "4.3.2"
@@ -2139,26 +2139,26 @@
       "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.5.2.tgz",
       "integrity": "sha512-uZn/gXkGmO5JBdopxNLSpFMS1lXr+KJqynI8Di1Qyr8ZVXt67ruh+XNfzLMVdLzYv+MQRdNYQdVwWPSs0qM7xQ=="
     },
-    "pg-packet-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
-      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
-    },
     "pg-pool": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
-      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.1.1.tgz",
+      "integrity": "sha512-kYH6S0mcZF1TPg1F9boFee2JlCSm2oqnlR2Mz2Wgn1psQbEBNVeNTJCw2wCK48QsctwvGUzbxLMg/lYV6hL/3A=="
     },
     "pg-promise": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-10.4.4.tgz",
-      "integrity": "sha512-N2NsOgKxrnNPwP0Q609ZmxmAZEo2TQ26SzSvlbZWQb8vteqUhOPpU/pHi9DGatJrPcXNoyr4xjRw42CNfEBg/w==",
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-10.5.3.tgz",
+      "integrity": "sha512-cfHgFpcqOc0IIRDABre//k1eda7s94Wys67P9r3q590nmvO0AzZucqWTVmgRUzNTIrDChUwY4hVOMBTIsU/ZiA==",
       "requires": {
-        "assert-options": "0.6.1",
-        "pg": "7.18.2",
+        "assert-options": "0.6.2",
+        "pg": "8.0.3",
         "pg-minify": "1.5.2",
         "spex": "3.0.1"
       }
+    },
+    "pg-protocol": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.2.2.tgz",
+      "integrity": "sha512-r8hGxHOk3ccMjjmhFJ/QOSVW5A+PP84TeRlEwB/cQ9Zu+bvtZg8Z59Cx3AMfVQc9S0Z+EG+HKhicF1W1GN5Eqg=="
     },
     "pg-types": {
       "version": "2.2.0",
@@ -2197,9 +2197,9 @@
       "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
     },
     "postgres-date": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.4.tgz",
-      "integrity": "sha512-bESRvKVuTrjoBluEcpv2346+6kgB7UlnqWZsnbnCccTNq/pqfj1j6oBaN5+b/NrDXepYUT/HKadqv3iS9lJuVA=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.5.tgz",
+      "integrity": "sha512-pdau6GRPERdAYUQwkBnGKxEfPyhVZXG/JiS44iZWiNdSOWE09N2lUgN6yshuq6fVSon4Pm0VMXd1srUUkLe9iA=="
     },
     "postgres-interval": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "nedb": "^1.8.0",
     "node-emoji": "^1.10.0",
     "p-queue": "^6.3.0",
-    "pg-promise": "^10.4.4",
+    "pg-promise": "^10.5.3",
     "quick-lru": "^5.0.0",
     "randomstring": "^1",
     "request-promise-native": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Matrix <--> Slack bridge",
   "main": "app.js",
   "scripts": {
-    "postinstall": "npm run build",
+    "prepare": "npm run build",
     "start": "node ./lib/app.js",
     "build": "tsc",
     "test": "npm run test:unit && npm run test:integration",


### PR DESCRIPTION
I have a suspicion that pg-promise broke on Node v14, as we're seeing people complaining about being unable to use postgres on the latest image, which is using Node v14.

To fix, I've updated pg-promise to a version compatible with Node v14, and also pinned us to Node v14 in order to ensure we don't get caught out next time. At some point, we should include Node v14 on our pipeline.