### PR TITLE
Update to pg-promise 10.5.5

### DIFF
--- a/changelog.d/410.misc
+++ b/changelog.d/410.misc
@@ -1,0 +1,1 @@
+Update to `pg-promise` 10.5.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -2103,14 +2103,14 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.0.3.tgz",
-      "integrity": "sha512-fvcNXn4o/iq4jKq15Ix/e58q3jPSmzOp6/8C3CaHoSR/bsxdg+1FXfDRePdtE/zBb3++TytvOrS1hNef3WC/Kg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.1.0.tgz",
+      "integrity": "sha512-Jp+XSNTGYDztc2FgIbmBXeeYMR7kKjfgnl3R+ioO6rkcxDmaea+YPp/gaxe13PBnJAFYyEGl0ixpwPm2gb6eUw==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "0.1.3",
-        "pg-pool": "^3.1.1",
+        "pg-connection-string": "^2.2.2",
+        "pg-pool": "^3.2.0",
         "pg-protocol": "^1.2.2",
         "pg-types": "^2.1.0",
         "pgpass": "1.x",
@@ -2125,9 +2125,9 @@
       }
     },
     "pg-connection-string": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
-      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.2.2.tgz",
+      "integrity": "sha512-+hel4DGuSZCjCZwglAuyi+XlodHnKmrbyTw0hVWlmGN2o4AfJDkDo5obAFzblS5M5PFBMx0uDt5Y1QjlNC+tqg=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -2135,30 +2135,30 @@
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-minify": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.5.2.tgz",
-      "integrity": "sha512-uZn/gXkGmO5JBdopxNLSpFMS1lXr+KJqynI8Di1Qyr8ZVXt67ruh+XNfzLMVdLzYv+MQRdNYQdVwWPSs0qM7xQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.6.0.tgz",
+      "integrity": "sha512-5Yxduh9Hul9Xev6uI3rSCypPk1kI7vI03ZPu5lgerrhiZ7QLj1Zd92SU2ZyalHVztlWnnPMnTZ+SeXJwh3eY9g=="
     },
     "pg-pool": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.1.1.tgz",
-      "integrity": "sha512-kYH6S0mcZF1TPg1F9boFee2JlCSm2oqnlR2Mz2Wgn1psQbEBNVeNTJCw2wCK48QsctwvGUzbxLMg/lYV6hL/3A=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.0.tgz",
+      "integrity": "sha512-7BLwDNDEfPFjE9vmZLcJPLFwuDAVGZ5lIZo2MeQfwYG7EPGfdNVis/dz6obI/yKqvQIx2sf6QBKXMLB+y/ftgA=="
     },
     "pg-promise": {
-      "version": "10.5.3",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-10.5.3.tgz",
-      "integrity": "sha512-cfHgFpcqOc0IIRDABre//k1eda7s94Wys67P9r3q590nmvO0AzZucqWTVmgRUzNTIrDChUwY4hVOMBTIsU/ZiA==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-10.5.5.tgz",
+      "integrity": "sha512-Ec2g5bN3uMD0wk65kNEgJbZOcyhQ0S37Gn9gAa78U9V7HcdTfMdpTRSRIFT0LHXpL1EcT00CW62+2Z4wAXs29A==",
       "requires": {
         "assert-options": "0.6.2",
-        "pg": "8.0.3",
-        "pg-minify": "1.5.2",
+        "pg": "8.1.0",
+        "pg-minify": "1.6.0",
         "spex": "3.0.1"
       }
     },
     "pg-protocol": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.2.2.tgz",
-      "integrity": "sha512-r8hGxHOk3ccMjjmhFJ/QOSVW5A+PP84TeRlEwB/cQ9Zu+bvtZg8Z59Cx3AMfVQc9S0Z+EG+HKhicF1W1GN5Eqg=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.2.3.tgz",
+      "integrity": "sha512-erHFURS0mPmTbq18cn/zNL3Y4IzNCrU4sgCim0qy7zAPe3Vc0rvK5cImJR6lDvIaz3fJU2R1R9FNOlnUtyF10Q=="
     },
     "pg-types": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "nedb": "^1.8.0",
     "node-emoji": "^1.10.0",
     "p-queue": "^6.3.0",
-    "pg-promise": "^10.5.3",
+    "pg-promise": "^10.5.5",
     "quick-lru": "^5.0.0",
     "randomstring": "^1",
     "request-promise-native": "^1.0.8",


### PR DESCRIPTION
In order to pull in `pg` 8.1, which allows us to use parameters like `?ssl=no-verify`