### PR TITLE
Load schema using absolute path

### DIFF
--- a/changelog.d/415.misc
+++ b/changelog.d/415.misc
@@ -1,0 +1,1 @@
+Load configuration schema using absolute path to make it possible to start the service from any directory.

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,11 +17,12 @@ limitations under the License.
 import { Logging, Cli, AppServiceRegistration } from "matrix-appservice-bridge";
 import { Main } from "./Main";
 import { IConfig } from "./IConfig";
+import * as path from "path";
 
 const cli = new Cli({
     bridgeConfig: {
         affectsRegistration: true,
-        schema: "config/slack-config-schema.yaml",
+        schema: path.join(__dirname, "../config/slack-config-schema.yaml"),
     },
     registrationPath: "slack-registration.yaml",
     generateRegistration(reg, callback) {


### PR DESCRIPTION
Same as matrix-org/matrix-appservice-gitter#99. This is probably the first time I had typescript file open in editor, let me know if something needs to be changed :grinning:

----

When the app was started from directory other than the top-level of the repository, following error happens:

```
fs.js:114
    throw err;
    ^
Error: ENOENT: no such file or directory, open 'config/slack-config-schema.yaml'
    at Object.openSync (fs.js:443:3)
    at Object.readFileSync (fs.js:343:35)
    at ConfigValidator._loadFromFile (/nix/store/kv4w6rqv49jimq961wq3l7mx10cwzbr9-node_matrix-appservice-slack-1.3.1/lib/node_modules/matrix-appservice-slack/node_modules/matrix-appservice-bridge/lib/components/config-validator.js:63:29)
    at new ConfigValidator (/nix/store/kv4w6rqv49jimq961wq3l7mx10cwzbr9-node_matrix-appservice-slack-1.3.1/lib/node_modules/matrix-appservice-slack/node_modules/matrix-appservice-bridge/lib/components/config-validator.js:29:28)
    at Cli._loadConfig (/nix/store/kv4w6rqv49jimq961wq3l7mx10cwzbr9-node_matrix-appservice-slack-1.3.1/lib/node_modules/matrix-appservice-slack/node_modules/matrix-appservice-bridge/lib/components/cli.js:159:21)
    at Cli._assignConfigFile (/nix/store/kv4w6rqv49jimq961wq3l7mx10cwzbr9-node_matrix-appservice-slack-1.3.1/lib/node_modules/matrix-appservice-slack/node_modules/matrix-appservice-bridge/lib/components/cli.js:144:23)
    at Cli.run (/nix/store/kv4w6rqv49jimq961wq3l7mx10cwzbr9-node_matrix-appservice-slack-1.3.1/lib/node_modules/matrix-appservice-slack/node_modules/matrix-appservice-bridge/lib/components/cli.js:139:10)
    at Object.<anonymous> (/nix/store/kv4w6rqv49jimq961wq3l7mx10cwzbr9-node_matrix-appservice-slack-1.3.1/lib/node_modules/matrix-appservice-slack/lib/app.js:57:5)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
```