### PR TITLE
Fix team_sync indentation in sample config

### DIFF
--- a/changelog.d/416.misc
+++ b/changelog.d/416.misc
@@ -1,0 +1,1 @@
+Fix `team_sync` indentation in the sample config.

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -94,11 +94,11 @@ team_sync:
   all:
     channels:
       enabled: false
-  #   whitelist: []
-  #   blacklist: []
-  #   alias_prefix: "slack_"
-  users:
-    enabled: false
+    # whitelist: []
+    # blacklist: []
+    # alias_prefix: "slack_"
+    users:
+      enabled: false
 
 provisioning:
   enabled: true


### PR DESCRIPTION
I think `users` should be on the same nesting level as `channels`.