### PR TITLE
Refactor account handling to solve account logout issues

### DIFF
--- a/changelog.d/419.feature
+++ b/changelog.d/419.feature
@@ -1,0 +1,1 @@
+Move matrix<->slack account links to a seperate table, and properly logout users.

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1119,7 +1119,7 @@ export class Main {
     }
 
     public async setUserAccessToken(userId: string, teamId: string, slackId: string, accessToken: string, puppeting: boolean) {
-        this.datastore.insertAccount(userId, slackId, teamId, accessToken);
+        await this.datastore.insertAccount(userId, slackId, teamId, accessToken);
         if (puppeting) {
             // Store it here too for puppeting.
             await this.datastore.setPuppetToken(teamId, slackId, userId, accessToken);
@@ -1163,14 +1163,14 @@ export class Main {
                 return { deleted: false, msg: "You are the only user connected to Slack. You must unlink your rooms before you can unlink your account"};
             }
             // Last account, but no bridged rooms. We can delete the team safely.
-            this.clientFactory.dropTeamClient(acct.teamId);
-            this.datastore.deleteTeam(acct.teamId);
+            await this.clientFactory.dropTeamClient(acct.teamId);
+            await this.datastore.deleteTeam(acct.teamId);
             log.info(`Removed team ${acct.teamId}`);
         } // or not even the last account, we can safely remove the team
 
         try {
             const client = await this.clientFactory.createClient(acct.accessToken);
-            await client.auth.revoke();    
+            await client.auth.revoke();
         } catch (ex) {
             log.warn('Tried to revoke auth token, but got:', ex);
             // Even if this fails, we remove the token locally.

--- a/src/Provisioning.ts
+++ b/src/Provisioning.ts
@@ -88,15 +88,9 @@ export class Provisioner {
     }
 
     private async determineSlackIdForRequest(matrixUserId, teamId) {
-        const matrixUser = await this.main.datastore.getMatrixUser(matrixUserId);
-        if (!matrixUser) {
-            // No Slack user entry found for MXID
-            return null;
-        }
-        const accounts: {[userId: string]: {team_id: string}} = matrixUser.get("accounts");
-        for (const [key, value] of Object.entries(accounts)) {
-            if (value.team_id === teamId) {
-                return key;
+        for (const account of await this.main.datastore.getAccountsForMatrixUser(matrixUserId)) {
+            if (account.teamId === teamId) {
+                return account.slackId;
             }
         }
         return null;
@@ -146,20 +140,15 @@ export class Provisioner {
     }
 
     @command("user_id", "slack_id")
-    private async logout(req, res, userId, slackId) {
+    private async logout(req: Request, res: Response, userId: string, slackId: string) {
         if (!this.main.oauth2) {
             res.status(HTTP_CODES.NOT_FOUND).json({
                 error: "OAuth2 not configured on this bridge",
             });
             return;
         }
-        let matrixUser = await this.main.datastore.getMatrixUser(userId);
-        matrixUser = matrixUser ? matrixUser : new MatrixUser(userId);
-        const accounts = matrixUser.get("accounts") || {};
-        delete accounts[slackId];
-        matrixUser.set("accounts", accounts);
-        await this.main.datastore.storeMatrixUser(matrixUser);
-        log.info(`Removed account ${slackId} from ${slackId}`);
+        const logoutResult = await this.main.logoutAccount(userId, slackId);
+        res.json({logoutResult});
     }
 
     @command("user_id", "team_id")
@@ -208,16 +197,14 @@ export class Provisioner {
     @command("user_id")
     private async teams(req, res, userId) {
         log.debug(`${userId} requested their teams`);
-        const matrixUser = await this.main.datastore.getMatrixUser(userId);
-        if (matrixUser === null) {
+        const accounts = await this.main.datastore.getAccountsForMatrixUser(userId);
+        if (accounts.length === 0) {
             res.status(HTTP_CODES.NOT_FOUND).json({error: "User has no accounts setup"});
             return;
         }
-        const accounts = matrixUser.get("accounts");
-        const results = await Promise.all(Object.keys(accounts).map(async (slackId) => {
-            const account = accounts[slackId];
-            return this.main.datastore.getTeam(account.team_id).then(
-                (team) => ({team, slack_id: slackId}),
+        const results = await Promise.all(accounts.map(async (account) => {
+            return this.main.datastore.getTeam(account.teamId).then(
+                (team) => ({team, slack_id: account.slackId}),
             );
         }));
         const teams = results.map((account) => ({

--- a/src/Provisioning.ts
+++ b/src/Provisioning.ts
@@ -206,7 +206,7 @@ export class Provisioner {
                 const team = await this.main.datastore.getTeam(account.teamId)
                 return {team, slack_id: account.slackId};
             })
-        }));
+        );
         const teams = results.map((account) => ({
             id: account.team!.id,
             name: account.team!.name,

--- a/src/Provisioning.ts
+++ b/src/Provisioning.ts
@@ -203,9 +203,9 @@ export class Provisioner {
             return;
         }
         const results = await Promise.all(accounts.map(async (account) => {
-            return this.main.datastore.getTeam(account.teamId).then(
-                (team) => ({team, slack_id: account.slackId}),
-            );
+                const team = await this.main.datastore.getTeam(account.teamId)
+                return {team, slack_id: account.slackId};
+            })
         }));
         const teams = results.map((account) => ({
             id: account.team!.id,

--- a/src/SlackHookHandler.ts
+++ b/src/SlackHookHandler.ts
@@ -345,8 +345,8 @@ export class SlackHookHandler extends BaseSlackHandler {
                 if (await this.main.willExceedTeamLimit(response.team_id)) {
                     log.warn(`User ${response.user_id} tried to add a new team ${response.team_id} but the team limit was reached`);
                     try {
-                        const tempClient = await this.main.clientFactory.createTeamClient(response.access_token);
-                        await tempClient.slackClient.auth.revoke();
+                        const slackClient = await this.main.clientFactory.createClient(response.access_token);
+                        await slackClient.auth.revoke();
                     } catch (ex) {
                         log.warn(`Additionally failed to revoke the token:`, ex);
                     }

--- a/src/datastore/Models.ts
+++ b/src/datastore/Models.ts
@@ -72,6 +72,13 @@ export interface PuppetEntry {
     token: string;
 }
 
+export interface SlackAccount {
+    matrixId: string;
+    teamId: string;
+    slackId: string;
+    accessToken: string;
+}
+
 export type RoomType = "user" | "channel";
 
 export interface Datastore {
@@ -81,6 +88,11 @@ export interface Datastore {
     getMatrixUser(userId: string): Promise<MatrixUser|null>;
     storeMatrixUser(user: MatrixUser): Promise<void>;
     getAllUsersForTeam(teamId: string): Promise<UserEntry[]>;
+
+    insertAccount(userId: string, slackId: string, teamId: string, accessToken: string): Promise<void>;
+    getAccountsForMatrixUser(userId: string): Promise<SlackAccount[]>;
+    getAccountsForTeam(teamId: string): Promise<SlackAccount[]>;
+    deleteAccount(userId: string, slackId: string): Promise<void>;
 
     // Rooms
     upsertRoom(room: BridgedRoom): Promise<void>;
@@ -97,6 +109,7 @@ export interface Datastore {
     upsertTeam(entry: TeamEntry);
     getTeam(teamId: string): Promise<TeamEntry|null>;
     getAllTeams(): Promise<TeamEntry[]>;
+    deleteTeam(teamId: string): Promise<void>;
 
     // Puppets
     setPuppetToken(teamId: string, slackUser: string, matrixId: string, token: string): Promise<void>;

--- a/src/datastore/NedbDatastore.ts
+++ b/src/datastore/NedbDatastore.ts
@@ -19,7 +19,7 @@ import {
     MatrixUser,
     EventStore, RoomStore, UserStore,
     StoredEvent } from "matrix-appservice-bridge";
-import { Datastore, UserEntry, RoomEntry, RoomType, TeamEntry, EventEntry, EventEntryExtra, PuppetEntry } from "./Models";
+import { Datastore, UserEntry, RoomEntry, RoomType, TeamEntry, EventEntry, EventEntryExtra, PuppetEntry, SlackAccount } from "./Models";
 import * as NedbDb from "nedb";
 
 export class NedbDatastore implements Datastore {
@@ -60,6 +60,53 @@ export class NedbDatastore implements Datastore {
     public async getAllUsersForTeam(teamId: string): Promise<UserEntry[]> {
         const users = await this.getAllUsers(false);
         return users.filter((u) => u.team_id === teamId);
+    }
+
+    public async insertAccount(userId: string, slackId: string, teamId: string, accessToken: string) {
+        let matrixUser = await this.getMatrixUser(userId);
+        matrixUser = matrixUser ? matrixUser : new MatrixUser(userId);
+        const accounts = matrixUser.get("accounts") || {};
+        accounts[slackId] = {
+            access_token: accessToken,
+            team_id: teamId,
+        };
+        matrixUser.set("accounts", accounts);
+        await this.storeMatrixUser(matrixUser);
+    }
+
+    public async getAccountsForMatrixUser(userId: string): Promise<SlackAccount[]> {
+        const matrixUser = await this.getMatrixUser(userId);
+        if (matrixUser === null) {
+            return [];
+        }
+        const accounts: {[slackId: string]: {team_id: string, access_token: string}} = matrixUser.get("accounts");
+        return Object.entries(accounts).map(([slackId, o]) => ({
+            matrixId: userId,
+            slackId,
+            teamId: o.team_id,
+            accessToken: o.access_token,
+        }))
+    }
+
+    public async getAccountsForTeam(teamId: string): Promise<SlackAccount[]> {
+        // TODO: Can we implement this?
+        return [];
+    }
+
+    public async deleteAccount(userId: string, slackId: string): Promise<void> {
+        const matrixUser = await this.getMatrixUser(userId);
+        if (!matrixUser) {
+            return;
+        }
+        const accounts = matrixUser.get("accounts") || {};
+        if (!accounts[slackId]) {
+            return;
+        }
+        const teamId = accounts[slackId].team_id;
+        // Identify if this is the only account.
+        delete accounts[slackId];
+        matrixUser.set("accounts", accounts);
+        await this.storeMatrixUser(matrixUser);
     }
 
     public async getMatrixUser(userId: string): Promise<MatrixUser|null> {
@@ -155,6 +202,11 @@ export class NedbDatastore implements Datastore {
     public async upsertTeam(entry: TeamEntry) {
         return this.teamStore.update({id: entry.id}, entry, {upsert: true});
     }
+
+    public async deleteTeam(teamId: string): Promise<void> {
+        return this.teamStore.remove({id: teamId});
+    }
+
 
     public async getTeam(teamId: string): Promise<TeamEntry|null> {
         return new Promise((resolve, reject) => {

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -19,7 +19,7 @@ import * as pgInit from "pg-promise";
 import { IDatabase, IMain } from "pg-promise";
 
 import { Logging, MatrixUser } from "matrix-appservice-bridge";
-import { Datastore, TeamEntry, RoomEntry, RoomType, UserEntry, EventEntry, EventEntryExtra, PuppetEntry } from "../Models";
+import { Datastore, TeamEntry, RoomEntry, RoomType, UserEntry, EventEntry, EventEntryExtra, PuppetEntry, SlackAccount } from "../Models";
 import { BridgedRoom } from "../../BridgedRoom";
 import { SlackGhost } from "../../SlackGhost";
 
@@ -74,6 +74,39 @@ export class PgDatastore implements Datastore {
             id: user.getId(),
             json: user.serialize(),
         });
+    }
+
+    public async insertAccount(userId: string, slackId: string, teamId: string, accessToken: string): Promise<void> {
+        log.debug(`getAccountsForMatrixUser: ${userId}`);
+        await this.postgresDb.none("INSERT INTO linked_accounts VALUES (${userId}, ${slackId}, ${teamId}, ${accessToken})", {
+            userId, slackId, teamId, accessToken 
+        });
+    }
+    public async getAccountsForMatrixUser(userId: string): Promise<SlackAccount[]> {
+        log.debug(`getAccountsForMatrixUser: ${userId}`);
+        const accounts = await this.postgresDb.manyOrNone("SELECT * FROM linked_accounts WHERE user_id = ${userId}", { userId });
+        return accounts.map((a) => ({
+            matrixId: a.user_id,
+            slackId: a.slack_id,
+            teamId: a.team_id,
+            accessToken: a.access_token,
+        }));
+    }
+
+    public async getAccountsForTeam(teamId: string): Promise<SlackAccount[]> {
+        log.debug(`getAccountsForTeam: ${teamId}`);
+        const accounts = await this.postgresDb.manyOrNone("SELECT * FROM linked_accounts WHERE team_id = ${teamId}", { teamId });
+        return accounts.map((a) => ({
+            matrixId: a.user_id,
+            slackId: a.slack_id,
+            teamId: a.team_id,
+            accessToken: a.access_token,
+        }));
+    }
+
+    public async deleteAccount(userId: string, slackId: string): Promise<void> {
+        log.info(`deleteAccount: ${userId} ${slackId}`);
+        await this.postgresDb.none("DELETE FROM linked_accounts WHERE slack_id = ${slackId} AND user_id = ${userId}", { userId, slackId });
     }
 
     public async upsertEvent(roomIdOrEntry: string|EventEntry, eventId?: string, channelId?: string, ts?: string, extras?: EventEntryExtra) {
@@ -209,6 +242,10 @@ export class PgDatastore implements Datastore {
             return null;
         }
         return PgDatastore.teamEntryForRow(doc);
+    }
+
+    public async deleteTeam(teamId: string): Promise<void> {
+        await this.postgresDb.none("DELETE FROM teams WHERE id = ${teamId}", { teamId });
     }
 
     public async getAllTeams(): Promise<TeamEntry[]> {

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -30,7 +30,7 @@ const pgp: IMain = pgInit({
 const log = Logging.get("PgDatastore");
 
 export class PgDatastore implements Datastore {
-    public static readonly LATEST_SCHEMA = 5;
+    public static readonly LATEST_SCHEMA = 6;
     // tslint:disable-next-line: no-any
     public readonly postgresDb: IDatabase<any>;
 
@@ -77,7 +77,8 @@ export class PgDatastore implements Datastore {
     }
 
     public async insertAccount(userId: string, slackId: string, teamId: string, accessToken: string): Promise<void> {
-        log.debug(`getAccountsForMatrixUser: ${userId}`);
+        log.debug(`insertAccount: ${userId}`);
+        console.log(...arguments);
         await this.postgresDb.none("INSERT INTO linked_accounts VALUES (${userId}, ${slackId}, ${teamId}, ${accessToken})", {
             userId, slackId, teamId, accessToken,
         });

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -78,7 +78,6 @@ export class PgDatastore implements Datastore {
 
     public async insertAccount(userId: string, slackId: string, teamId: string, accessToken: string): Promise<void> {
         log.debug(`insertAccount: ${userId}`);
-        console.log(...arguments);
         await this.postgresDb.none("INSERT INTO linked_accounts VALUES (${userId}, ${slackId}, ${teamId}, ${accessToken})", {
             userId, slackId, teamId, accessToken,
         });

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -79,7 +79,7 @@ export class PgDatastore implements Datastore {
     public async insertAccount(userId: string, slackId: string, teamId: string, accessToken: string): Promise<void> {
         log.debug(`getAccountsForMatrixUser: ${userId}`);
         await this.postgresDb.none("INSERT INTO linked_accounts VALUES (${userId}, ${slackId}, ${teamId}, ${accessToken})", {
-            userId, slackId, teamId, accessToken 
+            userId, slackId, teamId, accessToken,
         });
     }
     public async getAccountsForMatrixUser(userId: string): Promise<SlackAccount[]> {

--- a/src/datastore/postgres/schema/v6.ts
+++ b/src/datastore/postgres/schema/v6.ts
@@ -1,0 +1,34 @@
+import { IDatabase } from "pg-promise";
+import { MatrixUser } from "matrix-appservice-bridge";
+
+// tslint:disable-next-line: no-any
+export async function runSchema(db: IDatabase<any>) {
+    // Create database
+    await db.none(`
+        CREATE TABLE linked_accounts (
+            user_id TEXT NOT NULL,
+            slack_id TEXT NOT NULL,
+            team_id TEXT NOT NULL,
+            team_name TEXT NOT NULL,
+            access_token TEXT NOT NULL,
+            CONSTRAINT cons_linked_accounts_unique UNIQUE(user_id, slack_id)
+        );
+    `);
+    // Insert entries from users table.
+    const users = await db.manyOrNone("SELECT userid, json FROM users WHERE isremote = false;");
+    for (const userData of users) {
+        const user = new MatrixUser(userData.userid, JSON.parse(userData.json));
+        if (!user.get("accounts")) {
+            continue;
+        }
+        // tslint:disable-next-line: no-any
+        for (const [slack_id, account] of Object.entries<any>(user.get("accounts") || { })) {
+            await db.none("INSERT INTO linked_accounts VALUES (${user_id}, ${slack_id}, ${team_id}, ${team_name})", {
+                user_id: userData.userid,
+                slack_id,
+                team_id: account.team_id,
+                team_name: account.team_name,
+            });
+        }
+    }
+}

--- a/src/datastore/postgres/schema/v6.ts
+++ b/src/datastore/postgres/schema/v6.ts
@@ -10,7 +10,6 @@ export async function runSchema(db: IDatabase<any>) {
             user_id TEXT NOT NULL,
             slack_id TEXT NOT NULL,
             team_id TEXT NOT NULL,
-            team_name TEXT NOT NULL,
             access_token TEXT NOT NULL,
             CONSTRAINT cons_linked_accounts_unique UNIQUE(user_id, slack_id)
         );
@@ -18,8 +17,8 @@ export async function runSchema(db: IDatabase<any>) {
     // Insert entries from users table.
     const users = await db.manyOrNone("SELECT userid, json FROM users WHERE isremote = false;");
     const pgInstance = pgp();
-    const cs = new pgInstance.helpers.ColumnSet(['user_id', 'slack_id', 'team_id', 'team_name'], {table: 'linked_accounts'});
-    const values: {user_id: string, slack_id: string, team_id: string, team_name: string}[] = [];
+    const cs = new pgInstance.helpers.ColumnSet(['user_id', 'slack_id', 'team_id', 'access_token'], {table: 'linked_accounts'});
+    const values: {user_id: string, slack_id: string, team_id: string, access_token: string}[] = [];
     for (const userData of users) {
         const user = new MatrixUser(userData.userid, JSON.parse(userData.json));
         if (!user.get("accounts")) {
@@ -32,7 +31,7 @@ export async function runSchema(db: IDatabase<any>) {
                 user_id: userData.userid,
                 slack_id: slackId,
                 team_id: account.team_id,
-                team_name: account.team_name,
+                access_token: account.access_token,
             });
         }
     }

--- a/src/datastore/postgres/schema/v6.ts
+++ b/src/datastore/postgres/schema/v6.ts
@@ -1,9 +1,8 @@
-import { IDatabase } from "pg-promise";
 import * as pgp from "pg-promise";
 import { MatrixUser } from "matrix-appservice-bridge";
 
 // tslint:disable-next-line: no-any
-export async function runSchema(db: IDatabase<any>) {
+export async function runSchema(db: pgp.IDatabase<any>) {
     // Create database
     await db.none(`
         CREATE TABLE linked_accounts (
@@ -24,7 +23,7 @@ export async function runSchema(db: IDatabase<any>) {
         if (!user.get("accounts")) {
             continue;
         }
-        
+
         // tslint:disable-next-line: no-any
         for (const [slackId, account] of Object.entries<any>(user.get("accounts") || { })) {
             values.push({

--- a/src/datastore/postgres/schema/v6.ts
+++ b/src/datastore/postgres/schema/v6.ts
@@ -34,5 +34,7 @@ export async function runSchema(db: pgp.IDatabase<any>) {
             });
         }
     }
-    await db.none(pgInstance.helpers.insert(values, cs));
+    if (values.length) {
+        await db.none(pgInstance.helpers.insert(values, cs));
+    }
 }

--- a/src/tests/utils/fakeDatastore.ts
+++ b/src/tests/utils/fakeDatastore.ts
@@ -1,11 +1,27 @@
 import { MatrixUser } from "matrix-appservice-bridge";
-import { Datastore, UserEntry, RoomEntry, EventEntry, EventEntryExtra, TeamEntry, PuppetEntry, RoomType } from "../../datastore/Models";
+import { Datastore, UserEntry, RoomEntry, EventEntry, EventEntryExtra, TeamEntry, PuppetEntry, RoomType, SlackAccount } from "../../datastore/Models";
 import { SlackGhost } from "../../SlackGhost";
 import { BridgedRoom } from "../../BridgedRoom";
 
 export class FakeDatastore implements Datastore {
     constructor(public teams: TeamEntry[] = [], public usersInTeam: UserEntry[] = []) {
 
+    }
+
+    insertAccount(userId: string, slackId: string, teamId: string, accessToken: string): Promise<void> {
+        throw new Error("Method not implemented.");
+    }
+    getAccountsForMatrixUser(userId: string): Promise<SlackAccount[]> {
+        throw new Error("Method not implemented.");
+    }
+    getAccountsForTeam(teamId: string): Promise<SlackAccount[]> {
+        throw new Error("Method not implemented.");
+    }
+    deleteAccount(userId: string, slackId: string): Promise<void> {
+        throw new Error("Method not implemented.");
+    }
+    deleteTeam(teamId: string): Promise<void> {
+        throw new Error("Method not implemented.");
     }
 
     public async upsertUser(user: SlackGhost): Promise<void> {

--- a/src/tests/utils/fakeDatastore.ts
+++ b/src/tests/utils/fakeDatastore.ts
@@ -8,19 +8,23 @@ export class FakeDatastore implements Datastore {
 
     }
 
-    insertAccount(userId: string, slackId: string, teamId: string, accessToken: string): Promise<void> {
+    async insertAccount(userId: string, slackId: string, teamId: string, accessToken: string): Promise<void> {
         throw new Error("Method not implemented.");
     }
-    getAccountsForMatrixUser(userId: string): Promise<SlackAccount[]> {
+
+    async getAccountsForMatrixUser(userId: string): Promise<SlackAccount[]> {
         throw new Error("Method not implemented.");
     }
-    getAccountsForTeam(teamId: string): Promise<SlackAccount[]> {
+
+    async getAccountsForTeam(teamId: string): Promise<SlackAccount[]> {
         throw new Error("Method not implemented.");
     }
-    deleteAccount(userId: string, slackId: string): Promise<void> {
+
+    async deleteAccount(userId: string, slackId: string): Promise<void> {
         throw new Error("Method not implemented.");
     }
-    deleteTeam(teamId: string): Promise<void> {
+
+    async deleteTeam(teamId: string): Promise<void> {
         throw new Error("Method not implemented.");
     }
 


### PR DESCRIPTION
This PR does a lot, but unfortunately it's mostly intertwined and had to be done in a block. I'll try to explain the situation as it is now:

Currently, users run through the oauth flow and we store the resulting access token / slack id and team id into the "accounts" json object inside a `MatrixUser`, which is stored as a JSON blob in the database. A holdover from the NeDB days. This made it difficult to run queries to tell which users were connected to which slack team.

This became a problem for account logout / removing teams. There isn't a good way to tell if a team is unused, or the user is the last account holder for that team because iterating over all those JSON blobs is difficult. We deferred handling this, and simply deleted the account from the user object so they couldn't see their account, but the team would still be present in the database as we couldn't tell if the user was the last connected user for that team.

Fast forward to today where the team count is used to decide if a customer can bridge their team into their paid bridge, and suddenly those leftover teams matter. This change makes it so that we store the linked accounts in a separate table for easy querying, and that we properly clean up leftover teams and accounts so the team count matches up properly.