### PR TITLE
Fix puppets being constrained by team / matrix id

### DIFF
--- a/changelog.d/420.bugfix
+++ b/changelog.d/420.bugfix
@@ -1,0 +1,1 @@
+Fix issue where puppets could not be registered for the same team or mxid twice.

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -30,7 +30,7 @@ const pgp: IMain = pgInit({
 const log = Logging.get("PgDatastore");
 
 export class PgDatastore implements Datastore {
-    public static readonly LATEST_SCHEMA = 5;
+    public static readonly LATEST_SCHEMA = 7;
     // tslint:disable-next-line: no-any
     public readonly postgresDb: IDatabase<any>;
 

--- a/src/datastore/postgres/schema/v7.ts
+++ b/src/datastore/postgres/schema/v7.ts
@@ -1,0 +1,10 @@
+import { IDatabase } from "pg-promise";
+import { MatrixUser } from "matrix-appservice-bridge";
+
+// tslint:disable-next-line: no-any
+export async function runSchema(db: IDatabase<any>) {
+    // Drop constraints
+    await db.none(`
+        ALTER TABLE puppets DROP CONSTRAINT puppets_slackteam_key;
+        ALTER TABLE puppets DROP CONSTRAINT puppets_matrixuser_key;`);
+}


### PR DESCRIPTION
We accidentally made it so that two puppets could never be registered against the same mxid, or the same team_id. Let's fix that. Using `v7` because `v6` is part of #419 