### PR TITLE
Add optional display name suffix

### DIFF
--- a/changelog.d/433.feature
+++ b/changelog.d/433.feature
@@ -1,0 +1,1 @@
+Add optional display name suffix to Slack users. Contributed by Dexter Chua.

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -33,6 +33,7 @@ oauth2:
 
 # The prefix to give slack users 
 username_prefix: "slack_" # Required
+display_name_suffix: "[s]" # Optional
 
 homeserver: # Required
   # The domain name of your homeserver

--- a/config/slack-config-schema.yaml
+++ b/config/slack-config-schema.yaml
@@ -59,6 +59,8 @@ properties:
         type: string
   username_prefix:
     type: string
+  display_name_suffix:
+    type: string
   matrix_admin_room:
     type: string
   enable_metrics:

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -594,7 +594,7 @@ export class BridgedRoom {
         this.addRecentSlackMessage(message.ts);
         try {
             const ghost = await this.main.ghostStore.getForSlackMessage(message, this.slackTeamId!);
-            await ghost.update(message, this);
+            await ghost.update(message, this, this.main.config);
             await ghost.cancelTyping(this.MatrixRoomId); // If they were typing, stop them from doing that.
             this.slackSendLock = this.slackSendLock.finally(async () => {
                 return this.handleSlackMessage(message, ghost, content);
@@ -619,7 +619,7 @@ export class BridgedRoom {
             return;
         }
         const ghost = await this.main.ghostStore.getForSlackMessage(message, teamId);
-        await ghost.update(message, this);
+        await ghost.update(message, this, this.main.config);
 
         const event = await this.main.datastore.getEventBySlackId(message.item.channel, message.item.ts);
 

--- a/src/IConfig.ts
+++ b/src/IConfig.ts
@@ -28,6 +28,7 @@ export const CACHING_DEFAULTS = {
 export interface IConfig {
     inbound_uri_prefix?: string;
     username_prefix: string;
+    display_name_suffix?: string;
 
     matrix_admin_room?: string;
 

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -211,7 +211,7 @@ export class TeamSyncer {
         log.info(`Syncing user ${teamId} ${item.id}`);
         const slackGhost = await this.main.ghostStore.get(item.id, domain, teamId);
         if (item.deleted !== true) {
-            await slackGhost.updateFromISlackUser(item);
+            await slackGhost.updateFromISlackUser(item, this.main.config);
             return;
         }
         log.warn(`User ${item.id} has been deleted`);


### PR DESCRIPTION
This allows us to distinguish between Slack users and Matrix users. This
is especially useful when using Matrix as a bridging hub.