### PR TITLE
Consistently suggest to use port 5858 for the appservice

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,13 +7,13 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Launch on port 9999",
+            "name": "Launch on port 5858",
             "skipFiles": [
                 "<node_internals>/**"
             ],
             "program": "${workspaceFolder}/lib/app.js",
             "preLaunchTask": "npm: build",
-            "args": ["-c", "config/config.yaml", "-p", "9999"],
+            "args": ["-c", "config/config.yaml", "-p", "5858"],
             "outFiles": [
                 "${workspaceFolder}/**/*.js"
             ]

--- a/changelog.d/436.doc
+++ b/changelog.d/436.doc
@@ -1,0 +1,1 @@
+Consistently suggest to use port 5858 for the appservice

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -50,7 +50,7 @@ homeserver: # Required
   # max_upload_size: 104857600
   # Optional. Used to specify the port of the appservice in the config, rather than the cli.
   # If this is defined, it will **override** the port given in the process arguments.
-  # appservice_port: 9999
+  # appservice_port: 5858
 
 # Optional
 logging:


### PR DESCRIPTION
Our Docker image uses port TCP 5858, so we may as well suggest it as the appservice port consistently.