### PR TITLE
Update PgDatastore.ts (with modifications)

### DIFF
--- a/changelog.d/429.misc
+++ b/changelog.d/429.misc
@@ -1,0 +1,1 @@
+Misc improvements to PostgreSQL datastore. Thanks @vitaly-t!

--- a/src/datastore/Models.ts
+++ b/src/datastore/Models.ts
@@ -83,25 +83,25 @@ export type RoomType = "user" | "channel";
 
 export interface Datastore {
     // Users
-    upsertUser(user: SlackGhost): Promise<void>;
+    upsertUser(user: SlackGhost): Promise<null>;
     getUser(id: string): Promise<UserEntry|null>;
     getMatrixUser(userId: string): Promise<MatrixUser|null>;
-    storeMatrixUser(user: MatrixUser): Promise<void>;
+    storeMatrixUser(user: MatrixUser): Promise<null>;
     getAllUsersForTeam(teamId: string): Promise<UserEntry[]>;
 
-    insertAccount(userId: string, slackId: string, teamId: string, accessToken: string): Promise<void>;
+    insertAccount(userId: string, slackId: string, teamId: string, accessToken: string): Promise<null>;
     getAccountsForMatrixUser(userId: string): Promise<SlackAccount[]>;
     getAccountsForTeam(teamId: string): Promise<SlackAccount[]>;
-    deleteAccount(userId: string, slackId: string): Promise<void>;
+    deleteAccount(userId: string, slackId: string): Promise<null>;
 
     // Rooms
-    upsertRoom(room: BridgedRoom): Promise<void>;
-    deleteRoom(id: string): Promise<void>;
+    upsertRoom(room: BridgedRoom): Promise<null>;
+    deleteRoom(id: string): Promise<null>;
     getAllRooms(): Promise<RoomEntry[]>;
 
     // Events
-    upsertEvent(roomId: string, eventId: string, channelId: string, ts: string, extras?: EventEntryExtra): Promise<void>;
-    upsertEvent(roomIdOrEntry: EventEntry): Promise<void>;
+    upsertEvent(roomId: string, eventId: string, channelId: string, ts: string, extras?: EventEntryExtra): Promise<null>;
+    upsertEvent(roomIdOrEntry: EventEntry): Promise<null>;
     getEventByMatrixId(roomId: string, eventId: string): Promise<EventEntry|null>;
     getEventBySlackId(channelId: string, ts: string): Promise<EventEntry|null>;
 
@@ -109,21 +109,21 @@ export interface Datastore {
     upsertTeam(entry: TeamEntry);
     getTeam(teamId: string): Promise<TeamEntry|null>;
     getAllTeams(): Promise<TeamEntry[]>;
-    deleteTeam(teamId: string): Promise<void>;
+    deleteTeam(teamId: string): Promise<null>;
 
     // Puppets
-    setPuppetToken(teamId: string, slackUser: string, matrixId: string, token: string): Promise<void>;
+    setPuppetToken(teamId: string, slackUser: string, matrixId: string, token: string): Promise<null>;
     getPuppetTokenBySlackId(teamId: string, slackId: string): Promise<string|null>;
     getPuppetTokenByMatrixId(teamId: string, matrixId: string): Promise<string|null>;
     getPuppetMatrixUserBySlackId(teamId: string, slackId: string): Promise<string|null>;
-    removePuppetTokenByMatrixId(teamId: string, matrixId: string): Promise<void>;
+    removePuppetTokenByMatrixId(teamId: string, matrixId: string): Promise<null>;
     getPuppetsByMatrixId(userId: string): Promise<PuppetEntry[]>;
     getPuppetedUsers(): Promise<PuppetEntry[]>;
 
     // Admin rooms
     getUserAdminRoom(matrixId: string): Promise<string|null>;
     getUserForAdminRoom(roomId: string): Promise<string|null>;
-    setUserAdminRoom(matrixuser: string, roomId: string): Promise<void>;
+    setUserAdminRoom(matrixuser: string, roomId: string): Promise<null>;
 
     // Metrics
     /**
@@ -145,7 +145,7 @@ export interface Datastore {
      * @param room The room an action was taken in
      * @param date The date of the action (defaults to the current date)
      */
-    upsertActivityMetrics(user: MatrixUser | SlackGhost, room: BridgedRoom, date?: Date): Promise<void>;
+    upsertActivityMetrics(user: MatrixUser | SlackGhost, room: BridgedRoom, date?: Date): Promise<null>;
 
     /**
      * Get the number of connected rooms on this instance.

--- a/src/datastore/NedbDatastore.ts
+++ b/src/datastore/NedbDatastore.ts
@@ -62,7 +62,7 @@ export class NedbDatastore implements Datastore {
         return users.filter((u) => u.team_id === teamId);
     }
 
-    public async insertAccount(userId: string, slackId: string, teamId: string, accessToken: string) {
+    public async insertAccount(userId: string, slackId: string, teamId: string, accessToken: string): Promise<null> {
         let matrixUser = await this.getMatrixUser(userId);
         matrixUser = matrixUser ? matrixUser : new MatrixUser(userId);
         const accounts = matrixUser.get("accounts") || {};
@@ -71,7 +71,7 @@ export class NedbDatastore implements Datastore {
             team_id: teamId,
         };
         matrixUser.set("accounts", accounts);
-        await this.storeMatrixUser(matrixUser);
+        return this.storeMatrixUser(matrixUser);
     }
 
     public async getAccountsForMatrixUser(userId: string): Promise<SlackAccount[]> {
@@ -93,27 +93,27 @@ export class NedbDatastore implements Datastore {
         return [];
     }
 
-    public async deleteAccount(userId: string, slackId: string): Promise<void> {
+    public async deleteAccount(userId: string, slackId: string): Promise<null> {
         const matrixUser = await this.getMatrixUser(userId);
         if (!matrixUser) {
-            return;
+            return null;
         }
         const accounts = matrixUser.get("accounts") || {};
         if (!accounts[slackId]) {
-            return;
+            return null;
         }
         const teamId = accounts[slackId].team_id;
         // Identify if this is the only account.
         delete accounts[slackId];
         matrixUser.set("accounts", accounts);
-        await this.storeMatrixUser(matrixUser);
+        return this.storeMatrixUser(matrixUser);
     }
 
     public async getMatrixUser(userId: string): Promise<MatrixUser|null> {
         return (await this.userStore.getMatrixUser(userId)) || null;
     }
 
-    public async storeMatrixUser(user: MatrixUser): Promise<void> {
+    public async storeMatrixUser(user: MatrixUser): Promise<null> {
         return this.userStore.setMatrixUser(user);
     }
 
@@ -138,7 +138,7 @@ export class NedbDatastore implements Datastore {
     }
 
     public async upsertEvent(roomIdOrEntry: string|EventEntry,
-                             eventId?: string, channelId?: string, ts?: string, extras?: EventEntryExtra): Promise<void> {
+                             eventId?: string, channelId?: string, ts?: string, extras?: EventEntryExtra): Promise<null> {
         let storeEv: StoredEvent;
         if (typeof(roomIdOrEntry) === "string") {
             storeEv = new StoredEvent(
@@ -159,6 +159,7 @@ export class NedbDatastore implements Datastore {
             );
         }
         await this.eventStore.upsertEvent(storeEv);
+        return null;
     }
 
     private storedEventToEventEntry(storedEvent: StoredEvent): EventEntry {
@@ -203,8 +204,9 @@ export class NedbDatastore implements Datastore {
         return this.teamStore.update({id: entry.id}, entry, {upsert: true});
     }
 
-    public async deleteTeam(teamId: string): Promise<void> {
-        return this.teamStore.remove({id: teamId});
+    public async deleteTeam(teamId: string): Promise<null> {
+        this.teamStore.remove({id: teamId});
+        return null;
     }
 
 
@@ -241,13 +243,13 @@ export class NedbDatastore implements Datastore {
         });
     }
 
-    public async setPuppetToken(): Promise<void> {
+    public async setPuppetToken(): Promise<null> {
         // Puppeting not supported by NeDB - noop
-        return;
+        return null;
     }
 
-    public async removePuppetTokenByMatrixId() {
-        return;
+    public async removePuppetTokenByMatrixId(): Promise<null> {
+        return null;
     }
 
     public async getPuppetTokenBySlackId(): Promise<string|null> {
@@ -278,7 +280,7 @@ export class NedbDatastore implements Datastore {
         throw Error("Not supported on NeDB");
     }
 
-    public async setUserAdminRoom(): Promise<void> {
+    public async setUserAdminRoom(): Promise<null> {
         throw Error("Not supported on NeDB");
     }
 
@@ -292,9 +294,9 @@ export class NedbDatastore implements Datastore {
         return new Map();
     }
 
-    public async upsertActivityMetrics(user: MatrixUser | SlackGhost, room: BridgedRoom, date?: Date): Promise<void> {
+    public async upsertActivityMetrics(user: MatrixUser | SlackGhost, room: BridgedRoom, date?: Date): Promise<null> {
         // no-op; activity metrics are not implemented for NeDB
-        return;
+        return null;
     }
 
     public async getRoomCount(): Promise<number> {

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -41,10 +41,7 @@ export class PgDatastore implements Datastore {
     public async upsertUser(user: SlackGhost): Promise<void> {
         const entry = user.toEntry();
         log.debug(`upsertUser: ${entry.id}`);
-        await this.postgresDb.none("INSERT INTO users VALUES(${id}, true, ${json}) ON CONFLICT (userId) DO UPDATE SET json = ${json}", {
-            id: entry.id,
-            json: JSON.stringify(entry),
-        });
+        await this.postgresDb.none("INSERT INTO users VALUES(${id}, true, ${this}) ON CONFLICT (userId) DO UPDATE SET json = ${this}", entry);
     }
 
     public async getUser(id: string): Promise<UserEntry|null> {
@@ -68,46 +65,41 @@ export class PgDatastore implements Datastore {
         return users.map((dbEntry) => JSON.parse(dbEntry.json) as UserEntry);
     }
 
-    public async storeMatrixUser(user: MatrixUser): Promise<void> {
+    public async storeMatrixUser(user: MatrixUser): Promise<null> {
         log.debug(`storeMatrixUser: ${user.getId()}`);
-        await this.postgresDb.none("INSERT INTO users VALUES(${id}, false, ${json}) ON CONFLICT (userId) DO UPDATE SET json = ${json}", {
-            id: user.getId(),
-            json: user.serialize(),
-        });
+        return this.postgresDb.none("INSERT INTO users VALUES(${getId}, false, ${serialize}) ON CONFLICT (userId) DO UPDATE SET json = ${serialize}", user);
     }
 
-    public async insertAccount(userId: string, slackId: string, teamId: string, accessToken: string): Promise<void> {
+    public async insertAccount(userId: string, slackId: string, teamId: string, accessToken: string): Promise<null> {
         log.debug(`insertAccount: ${userId}`);
-        await this.postgresDb.none("INSERT INTO linked_accounts VALUES (${userId}, ${slackId}, ${teamId}, ${accessToken}) " +
+        return this.postgresDb.none("INSERT INTO linked_accounts VALUES (${userId}, ${slackId}, ${teamId}, ${accessToken}) " +
         "ON CONFLICT ON CONSTRAINT cons_linked_accounts_unique DO UPDATE SET access_token = ${accessToken}", {
             userId, slackId, teamId, accessToken,
         });
     }
     public async getAccountsForMatrixUser(userId: string): Promise<SlackAccount[]> {
         log.debug(`getAccountsForMatrixUser: ${userId}`);
-        const accounts = await this.postgresDb.manyOrNone("SELECT * FROM linked_accounts WHERE user_id = ${userId}", { userId });
-        return accounts.map((a) => ({
+        return this.postgresDb.map("SELECT * FROM linked_accounts WHERE user_id = ${userId}", { userId }, a => {
             matrixId: a.user_id,
             slackId: a.slack_id,
             teamId: a.team_id,
-            accessToken: a.access_token,
-        }));
+            accessToken: a.access_token,            
+        });
     }
 
     public async getAccountsForTeam(teamId: string): Promise<SlackAccount[]> {
         log.debug(`getAccountsForTeam: ${teamId}`);
-        const accounts = await this.postgresDb.manyOrNone("SELECT * FROM linked_accounts WHERE team_id = ${teamId}", { teamId });
-        return accounts.map((a) => ({
+        return this.postgresDb.map("SELECT * FROM linked_accounts WHERE team_id = ${teamId}", { teamId }, a => {
             matrixId: a.user_id,
             slackId: a.slack_id,
             teamId: a.team_id,
             accessToken: a.access_token,
-        }));
+        });
     }
 
-    public async deleteAccount(userId: string, slackId: string): Promise<void> {
+    public async deleteAccount(userId: string, slackId: string): Promise<null> {
         log.info(`deleteAccount: ${userId} ${slackId}`);
-        await this.postgresDb.none("DELETE FROM linked_accounts WHERE slack_id = ${slackId} AND user_id = ${userId}", { userId, slackId });
+        return this.postgresDb.none("DELETE FROM linked_accounts WHERE slack_id = ${slackId} AND user_id = ${userId}", { userId, slackId });
     }
 
     public async upsertEvent(roomIdOrEntry: string|EventEntry, eventId?: string, channelId?: string, ts?: string, extras?: EventEntryExtra) {
@@ -122,7 +114,7 @@ export class PgDatastore implements Datastore {
             };
         }
         log.debug(`upsertEvent: ${entry.roomId} ${entry.eventId} ${entry.slackChannelId} ${entry.slackTs}`);
-        await this.postgresDb.none("INSERT INTO events VALUES(${roomId}, ${eventId}, ${slackChannelId}, ${slackTs}, ${jsonExtras}) " +
+        return this.postgresDb.none("INSERT INTO events VALUES(${roomId}, ${eventId}, ${slackChannelId}, ${slackTs}, ${jsonExtras}) " +
                            "ON CONFLICT ON CONSTRAINT cons_events_unique DO UPDATE SET extras = ${jsonExtras}", {
             ...entry,
             jsonExtras: JSON.stringify(entry._extras),
@@ -130,35 +122,27 @@ export class PgDatastore implements Datastore {
     }
 
     public async getEventByMatrixId(roomId: string, eventId: string): Promise<EventEntry|null> {
-        const dbEntry = await this.postgresDb.oneOrNone(
+        return this.postgresDb.oneOrNone(
             "SELECT * FROM events WHERE roomId = ${roomId} AND eventId = ${eventId}",
-            { roomId, eventId });
-        if (!dbEntry) {
-            return null;
-        }
-        return {
-            roomId,
-            eventId,
-            slackChannelId: dbEntry.slackchannel,
-            slackTs: dbEntry.slackts,
-            _extras: JSON.parse(dbEntry.extras),
-        };
+            { roomId, eventId }, e => e && {
+              roomId,
+              eventId,
+              slackChannelId: e.slackchannel,
+              slackTs: e.slackts,
+              _extras: JSON.parse(e.extras),
+        });
     }
 
     public async getEventBySlackId(slackChannel: string, slackTs: string): Promise<EventEntry|null> {
-        const dbEntry = await this.postgresDb.oneOrNone(
+        return this.postgresDb.oneOrNone(
             "SELECT * FROM events WHERE slackChannel = ${slackChannel} AND slackTs = ${slackTs}",
-            { slackChannel, slackTs });
-        if (!dbEntry) {
-            return null;
-        }
-        return {
-            roomId: dbEntry.roomid,
-            eventId: dbEntry.eventid,
-            slackChannelId: slackChannel,
-            slackTs,
-            _extras: JSON.parse(dbEntry.extras),
-        };
+            { slackChannel, slackTs }, e => e && {
+                roomId: e.roomid,
+                eventId: e.eventid,
+                slackChannelId: slackChannel,
+                slackTs,
+                _extras: JSON.parse(e.extras),
+        });
     }
 
     public async ensureSchema() {

--- a/src/tests/utils/fakeDatastore.ts
+++ b/src/tests/utils/fakeDatastore.ts
@@ -8,7 +8,7 @@ export class FakeDatastore implements Datastore {
 
     }
 
-    async insertAccount(userId: string, slackId: string, teamId: string, accessToken: string): Promise<void> {
+    async insertAccount(userId: string, slackId: string, teamId: string, accessToken: string): Promise<null> {
         throw new Error("Method not implemented.");
     }
 
@@ -20,16 +20,17 @@ export class FakeDatastore implements Datastore {
         throw new Error("Method not implemented.");
     }
 
-    async deleteAccount(userId: string, slackId: string): Promise<void> {
+    async deleteAccount(userId: string, slackId: string): Promise<null> {
         throw new Error("Method not implemented.");
     }
 
-    async deleteTeam(teamId: string): Promise<void> {
+    async deleteTeam(teamId: string): Promise<null> {
         throw new Error("Method not implemented.");
     }
 
-    public async upsertUser(user: SlackGhost): Promise<void> {
+    public async upsertUser(user: SlackGhost): Promise<null> {
         this.usersInTeam.push(user.toEntry());
+        return null;
     }
 
     public async getUser(id: string): Promise<UserEntry | null> {
@@ -40,7 +41,7 @@ export class FakeDatastore implements Datastore {
         throw Error("Method not implemented.");
     }
 
-    public async storeMatrixUser(user: MatrixUser): Promise<void> {
+    public async storeMatrixUser(user: MatrixUser): Promise<null> {
         throw Error("Method not implemented.");
     }
 
@@ -48,11 +49,11 @@ export class FakeDatastore implements Datastore {
         return this.usersInTeam;
     }
 
-    public async upsertRoom(room: BridgedRoom): Promise<void> {
+    public async upsertRoom(room: BridgedRoom): Promise<null> {
         throw Error("Method not implemented.");
     }
 
-    public async deleteRoom(id: string): Promise<void> {
+    public async deleteRoom(id: string): Promise<null> {
         throw Error("Method not implemented.");
     }
 
@@ -60,11 +61,11 @@ export class FakeDatastore implements Datastore {
         throw Error("Method not implemented.");
     }
 
-    public async upsertEvent(roomId: string, eventId: string, channelId: string, ts: string, extras?: EventEntryExtra | undefined): Promise<void>;
+    public async upsertEvent(roomId: string, eventId: string, channelId: string, ts: string, extras?: EventEntryExtra): Promise<null>;
 
-    public async upsertEvent(roomIdOrEntry: EventEntry): Promise<void>;
+    public async upsertEvent(roomIdOrEntry: EventEntry): Promise<null>;
 
-    public async upsertEvent(roomId: any, eventId?: any, channelId?: any, ts?: any, extras?: any) {
+    public async upsertEvent(roomId: any, eventId?: any, channelId?: any, ts?: any, extras?: any): Promise<null> {
         throw Error("Method not implemented.");
     }
 
@@ -93,7 +94,7 @@ export class FakeDatastore implements Datastore {
         return this.teams;
     }
 
-    public async setPuppetToken(teamId: string, slackUser: string, matrixId: string, token: string): Promise<void> {
+    public async setPuppetToken(teamId: string, slackUser: string, matrixId: string, token: string): Promise<null> {
         throw Error("Method not implemented.");
     }
 
@@ -105,7 +106,7 @@ export class FakeDatastore implements Datastore {
         return null;
     }
 
-    public async removePuppetTokenByMatrixId(teamId: string, matrixId: string): Promise<void> {
+    public async removePuppetTokenByMatrixId(teamId: string, matrixId: string): Promise<null> {
         throw Error("Method not implemented.");
     }
 
@@ -129,7 +130,7 @@ export class FakeDatastore implements Datastore {
         return null;
     }
 
-    public async setUserAdminRoom(matrixuser: string, roomid: string): Promise<void> {
+    public async setUserAdminRoom(matrixuser: string, roomid: string): Promise<null> {
         throw Error("Method not implemented.");
     }
 
@@ -141,8 +142,8 @@ export class FakeDatastore implements Datastore {
         return new Map();
     }
 
-    public async upsertActivityMetrics(user: MatrixUser | SlackGhost, room: BridgedRoom, date?: Date): Promise<void> {
-        return;
+    public async upsertActivityMetrics(user: MatrixUser | SlackGhost, room: BridgedRoom, date?: Date): Promise<null> {
+        return null;
     }
 
     public async getRoomCount() {


### PR DESCRIPTION
This is #429 with modifications to make our TypeScript types happy.

Added by me:
 * Fixed: .map() was not returning an object.
 * Changed: All database methods that returned `void` now return `null` for consistency and because that's what our main storage lig `pg-promise` does.

New PR because for some reason Git did not want to push to the old branch. :/
If you figure out how, you can also cherry-pick 0fca58486e7ce474937766678f3ae92c11488a93 onto the other branch.