### PR TITLE
Print the correct appservice port on the console when using the one from the config

### DIFF
--- a/changelog.d/440.bugfix
+++ b/changelog.d/440.bugfix
@@ -1,0 +1,1 @@
+Print the correct appservice port on the console when using the one from the config

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -765,6 +765,9 @@ export class Main {
         });
     }
 
+    /**
+     * Ensures the bridge bot is registered and updates its profile info.
+     */
     private async applyBotProfile() {
         log.info("Ensuring the bridge bot is registered");
         const intent = this.botIntent;
@@ -780,7 +783,12 @@ export class Main {
         }
     }
 
-    public async run(cliPort: number) {
+    /**
+     * Starts the bridge.
+     * @param cliPort A port to listen to provided by the user via a CLI option.
+     * @returns The port the appservice listens to.
+     */
+    public async run(cliPort: number): Promise<number> {
         log.info("Loading databases");
         if (this.oauth2) {
             await this.oauth2.compileTemplates();
@@ -963,6 +971,7 @@ export class Main {
         await teamSyncPromise;
         log.info("Bridge initialised");
         this.ready = true;
+        return port;
     }
 
     private async startupLoadRoomEntry(entry: RoomEntry, joinedRooms: string[], teamClients: {[teamId: string]: WebClient}) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -34,11 +34,11 @@ const cli = new Cli({
         reg.addRegexPattern("users", `@${config.username_prefix}.*:${config.homeserver.server_name}`, true);
         callback(reg);
     },
-    run(port: number, config: IConfig, registration: any) {
+    run(cliPort: number, config: IConfig, registration: any) {
         Logging.configure(config.logging || {});
         const log = Logging.get("app");
         const main = new Main(config, registration);
-        main.run(port).then(() => {
+        main.run(cliPort).then((port) => {
             log.info("Matrix-side listening on port", port);
         }).catch((ex) => {
             log.error("Failed to start:", ex);


### PR DESCRIPTION
Fixes #441

The CLI class expects its port to be used but the bridge may override that with an optional value from the config.

Only affects console output. The behaviour was not actually broken.