### PR TITLE
Stop Team Sync from calling Slack's API more rapidly than configured

### DIFF
--- a/changelog.d/454.bugfix
+++ b/changelog.d/454.bugfix
@@ -1,0 +1,1 @@
+Stop Team Sync from calling Slack's API more rapidly than configured

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -108,7 +108,8 @@ export class TeamSyncer {
 
             cursor = res.response_metadata.next_cursor;
             if (cursor !== "") {
-                const ms = Math.min(TEAM_SYNC_MIN_WAIT, Math.random() * TEAM_SYNC_MAX_WAIT);
+                // Get an evenly distributed number >= TEAM_SYNC_MIN_WAIT and < TEAM_SYNC_MAX_WAIT.
+                const ms = Math.random() * (TEAM_SYNC_MAX_WAIT - TEAM_SYNC_MIN_WAIT) + TEAM_SYNC_MIN_WAIT;
                 log.info(`Waiting ${ms}ms before returning more rows`);
                 await new Promise((r) => setTimeout(
                     r,


### PR DESCRIPTION
## The problem
The random delay before calling Slack's API for more channels or users is calculated incorrectly.

1. `Math.random() * anything` can be 0. Given a minimum is specified, this will give us an uneven distribution, leaning to the minimum.
2. `Math.min()` gave us the smaller number, which means the result was always between 0 and MIN, not between MIN and MAX.

## Assumptions
My new implementation assumes that MIN is below MAX and that both are positive. I think having no validation is reasonable, as the numbers are specified in code and not configurable.