### PR TITLE
Fix NedbDatastore.getTeam when an error happened or the team doesn't exist

### DIFF
--- a/changelog.d/455.bugfix
+++ b/changelog.d/455.bugfix
@@ -1,0 +1,1 @@
+Fix NedbDatastore.getTeam when an error happened or the team doesn't exist

--- a/src/datastore/NedbDatastore.ts
+++ b/src/datastore/NedbDatastore.ts
@@ -217,6 +217,7 @@ export class NedbDatastore implements Datastore {
             this.teamStore.findOne({id: teamId}, (err: Error|null, doc: any) => {
                 if (err || !doc) {
                     resolve(null);
+                    return;
                 }
                 // We don't use this.
                 delete doc._id;


### PR DESCRIPTION
Fixes #352 by returning after resolving.