### PR TITLE
Correctly bubble up rejected promises from TeamSync

### DIFF
--- a/changelog.d/456.bugfix
+++ b/changelog.d/456.bugfix
@@ -1,0 +1,1 @@
+TeamSync failures now consistently result in the bridge not starting. This previously resulted in an uncaught Promise.

--- a/changelog.d/456.bugfix
+++ b/changelog.d/456.bugfix
@@ -1,1 +1,1 @@
-TeamSync failures now consistently result in the bridge not starting. This previously resulted in an uncaught Promise.
+Correctly handle TeamSync failures, which displays a warning but does start the bridge. This previously resulted in an uncaught Promise.

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -15,8 +15,7 @@ limitations under the License.
 */
 
 import { Bridge, PrometheusMetrics, Gauge, StateLookup,
-    Logging, Intent,
-    Request } from "matrix-appservice-bridge";
+    Logging, Intent, Request } from "matrix-appservice-bridge";
 import * as path from "path";
 import * as randomstring from "randomstring";
 import { WebClient } from "@slack/web-api";

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -934,9 +934,7 @@ export class Main {
 
         const entries = await this.datastore.getAllRooms();
         log.info(`Found ${entries.length} room entries in store`);
-        i = 0;
-        await Promise.all(entries.map(async (entry) => {
-            i++;
+        await Promise.all(entries.map(async (entry, i) => {
             log.info(`[${i}/${entries.length}] Loading room entry ${entry.matrix_id}`);
             try {
                 await this.startupLoadRoomEntry(entry, joinedRooms as string[], teamClients);

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { Bridge, PrometheusMetrics, Gauge, StateLookup,
-    Logging, Intent, MatrixUser as BridgeMatrixUser,
+    Logging, Intent,
     Request } from "matrix-appservice-bridge";
 import * as path from "path";
 import * as randomstring from "randomstring";

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -22,7 +22,6 @@ import { ConversationsInfoResponse, UsersInfoResponse, ConversationsListResponse
 import { WebClient } from "@slack/web-api";
 import PQueue from "p-queue";
 import { ISlackUser } from "./BaseSlackHandler";
-import { promises } from "fs";
 
 const log = Logging.get("TeamSyncer");
 

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -60,21 +60,22 @@ export class TeamSyncer {
 
     public async syncAllTeams(teamClients: { [id: string]: WebClient; }) {
         const queue = new PQueue({concurrency: TEAM_SYNC_CONCURRENCY});
+        const functionsForQueue: (() => Promise<void>)[] = [];
         for (const [teamId, client] of Object.entries(teamClients)) {
             if (!this.getTeamSyncConfig(teamId)) {
                 log.debug(`Not syncing ${teamId}, team is not configured to sync`);
                 continue;
             }
-            // tslint:disable-next-line: no-floating-promises
-            queue.add((async () => {
+            functionsForQueue.push(async () => {
                 log.info("Syncing team", teamId);
                 await this.syncItems(teamId, client, "user");
                 await this.syncItems(teamId, client, "channel");
-            }));
+            });
         }
         try {
             log.info("Waiting for all teams to sync");
-            await queue.onIdle();
+            // .addAll waits for all promises to resolve.
+            await queue.addAll(functionsForQueue);
             log.info("All teams have synced");
         } catch (ex) {
             log.error("There was an issue when trying to sync teams:", ex);
@@ -117,19 +118,20 @@ export class TeamSyncer {
                 ));
             }
         }
-        const queue = new PQueue({concurrency: TEAM_SYNC_ITEM_CONCURRENCY});
         log.info(`Found ${itemList.length} total ${type}s`);
         const team = await this.main.datastore.getTeam(teamId);
         if (!team || !team.domain) {
             throw Error("No team domain!");
         }
-        const syncFunctionPromises: (() => Promise<void>)[] = [];
-        for (const item of itemList) {
-            syncFunctionPromises.push((type === "channel")
+        // Create all functions that will create promises.
+        // With .bind(this, ...params) they won't immediately execute.
+        const syncFunctionPromises = itemList.map(item => (
+            (type === "channel")
                 ? this.syncChannel.bind(this, teamId, item)
                 : this.syncUser.bind(this, teamId, team.domain, item)
-            );
-        }
+        ));
+        const queue = new PQueue({ concurrency: TEAM_SYNC_ITEM_CONCURRENCY });
+        // .addAll waits for all promises to resolve.
         await queue.addAll(syncFunctionPromises);
     }
 


### PR DESCRIPTION
## Floating promises could lead to uncaught errors in TeamSync
Failing user or channel syncs are currently resulting in an uncaught promise. That a deprecated functionality of Node, which will crash the end the process soon anyway and would lead to inconsistent behaviour.

## .setAvatarUrl threw because Synapse doesn't like undefined
Also, .setAvatarUrl requires a string. The Element client resets the avatar by providing an empty array, so this fixes #453.

## Broken counter for creating team clients
```javascript
const teams = [,,];
const promiseFunctions = [];
let i = 0;
for (const team of teams) {
    i++;
    promiseFunctions.push(async() => {
        console.log(`${i} of ${teams.length}`);
    });
}
promiseFunctions.forEach(func => func());
```
outputs
```
3 of 3
3 of 3
3 of 3
```
because at the time the promises execute, the variable `i` from the outer context already has its final value 3.