### PR TITLE
Sync users and channels on new team setup

### DIFF
--- a/changelog.d/475.feature
+++ b/changelog.d/475.feature
@@ -1,0 +1,1 @@
+When a user connects their team for the first time, sync members and channels!

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1221,7 +1221,7 @@ export class Main {
                     "user",
                 );
             } catch (ex) {
-                log.info("Failed to sync members", ex);
+                log.warn("Failed to sync members", ex);
             }
 
             try {
@@ -1231,7 +1231,7 @@ export class Main {
                     "channel",
                 );
             } catch (ex) {
-                log.info("Failed to sync channels", ex);
+                log.warn("Failed to sync channels", ex);
             }
         }
     }

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1231,7 +1231,7 @@ export class Main {
                     "channel",
                 );
             } catch (ex) {
-                log.info("Failed to sync members", ex);
+                log.info("Failed to sync channels", ex);
             }
         }
     }


### PR DESCRIPTION
We currently sync users and channels on startup, but this less useful if you've just added your team.