### PR TITLE
Add configuration to deny slack channels by name or ID

### DIFF
--- a/changelog.d/476.feature
+++ b/changelog.d/476.feature
@@ -1,0 +1,2 @@
+New configuration option `provisioning.channel_adl` to manage which Slack channels may be bridged.
+New configuration option `team_sync.*.allow_private` to allow/deny bridging private channels.

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -109,6 +109,17 @@ provisioning:
   limits:
     room_count: 20
     team_count: 1
+  # Allow deny list for which Slack channels may be bridged.
+  # If allow is defined, all other channels are blocked by default
+  # If deny is defined, all other channels are allowed by default
+  # If both are defined, allow takes precedence.
+  channel_adl:
+    allow: 
+      - "CCZ41UJV7"
+      - "#open.*"
+    deny:
+      - "CRBCPA771"
+      - "#secret.*"
 
 puppeting:
   # Should the bridge allow users to puppet their accounts

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -81,6 +81,8 @@ team_sync:
   # T0123ABCDEF:
   #   channels:
   #     enabled: true
+  #     # Allow or deny private channels from being synced. Defaults to true.
+  #     allow_private: true
   #     # Optional blacklist for channel ids. Trumps the whitelist.
   #     # blacklist: ['CVCCPEY9X', 'C0108F9K37X']
   #     # Optional whitelist for channel ids.

--- a/config/slack-config-schema.yaml
+++ b/config/slack-config-schema.yaml
@@ -121,6 +121,17 @@ properties:
             type: number
           team_count:
             type: number
+      channel_adl:
+        type: object
+        properties:
+          allow:
+            type: "array"
+            items:
+                type: "string"
+          deny:
+            type: "array"
+            items:
+                type: "string"
   puppeting:
     type: object
     required: ["enabled"]

--- a/config/slack-config-schema.yaml
+++ b/config/slack-config-schema.yaml
@@ -89,6 +89,8 @@ properties:
           properties:
             enabled:
               type: boolean
+            allow_private:
+              type: boolean
             whitelist:
               type: "array"
               items:

--- a/src/AllowDenyList.ts
+++ b/src/AllowDenyList.ts
@@ -11,6 +11,11 @@ export interface AllowDenyConfig {
     }
 }
 
+export interface AllowDenyConfigSimple {
+    allow?: string[];
+    deny?: string[];
+}
+
 export enum DenyReason {
     ALLOWED,
     MATRIX,
@@ -30,27 +35,37 @@ export class AllowDenyList {
         return new RegExp(str);
     }
 
-    private allow?: {
+    private dmAllow?: {
         matrix: RegExp[];
         slack: RegExp[];
     };
-    private deny?: {
+
+    private dmDeny?: {
         matrix: RegExp[];
         slack: RegExp[];
-    }
+    };
 
-    constructor(config: AllowDenyConfig = {}) {
-        if (config.allow) {
-            this.allow = {
-                matrix: (config.allow.matrix || []).map(AllowDenyList.convertToRegex),
-                slack: (config.allow.slack || []).map(AllowDenyList.convertToRegex)
+    private slackChannelAllow?: RegExp[];
+    private slackChannelDeny?: RegExp[];
+
+    constructor(dmConfig?: AllowDenyConfig, slackChannelConfig?: AllowDenyConfigSimple) {
+        if (dmConfig?.allow) {
+            this.dmAllow = {
+                matrix: (dmConfig.allow.matrix || []).map(AllowDenyList.convertToRegex),
+                slack: (dmConfig.allow.slack || []).map(AllowDenyList.convertToRegex)
             };
         }
-        if (config.deny) {
-            this.deny = {
-                matrix: (config.deny.matrix || []).map(AllowDenyList.convertToRegex),
-                slack: (config.deny.slack || []).map(AllowDenyList.convertToRegex)
+        if (dmConfig?.deny) {
+            this.dmDeny = {
+                matrix: (dmConfig.deny.matrix || []).map(AllowDenyList.convertToRegex),
+                slack: (dmConfig.deny.slack || []).map(AllowDenyList.convertToRegex)
             };
+        }
+        if (slackChannelConfig?.allow) {
+            this.slackChannelAllow = slackChannelConfig.allow.map(AllowDenyList.convertToRegex);
+        }
+        if (slackChannelConfig?.deny) {
+            this.slackChannelDeny = slackChannelConfig.deny.map(AllowDenyList.convertToRegex);
         }
     }
 
@@ -60,7 +75,7 @@ export class AllowDenyList {
      * @param matrixUser The Matrix MXID
      */
     public allowDM(matrixUser: string, slackUser: string, slackUsername?: string): DenyReason {
-        const allow = this.allow;
+        const allow = this.dmAllow;
         if (allow && allow.matrix?.length > 0 && !allow.matrix.some((e) => e.test(matrixUser))) {
             return DenyReason.MATRIX; // Matrix user was not on the allow list
         }
@@ -69,7 +84,7 @@ export class AllowDenyList {
             return DenyReason.SLACK; // Slack user was not on the allow list
         }
 
-        const deny = this.deny;
+        const deny = this.dmDeny;
         if (deny && deny.matrix?.length > 0 && deny.matrix.some((e) => e.test(matrixUser))) {
             return DenyReason.MATRIX; // Matrix user was on the deny list
         }
@@ -77,6 +92,33 @@ export class AllowDenyList {
         if (deny && deny.slack?.length > 0 && deny.slack.some((e) => e.test(slackUser) ||
             (slackUsername && e.test(slackUsername)))) {
             return DenyReason.SLACK; // Slack user was on the deny list
+        }
+
+        return DenyReason.ALLOWED;
+    }
+
+    /**
+     * Check if a Slack channel can be bridged.
+     * @param slackChannelId The Slack channel ID   e.g. CCZ41UJV7
+     * @param slackChannelName The Slack channel name e.g. #general
+     */
+    public allowSlackChannel(slackChannelId: string, slackChannelName?: string) {
+        if (slackChannelName?.startsWith('#')) {
+            slackChannelName = slackChannelName.slice(1);
+        }
+
+        // Test against both general and #general.
+        const testSlackChannel = (regex: RegExp) =>
+            regex.test(slackChannelId) || (slackChannelName && (regex.test(slackChannelName) || regex.test(`#${slackChannelName}`)));
+
+        const allow = this.slackChannelAllow;
+        if (allow && allow.length > 0 && !allow.some(testSlackChannel)) {
+            return DenyReason.SLACK;
+        }
+
+        const deny = this.slackChannelDeny;
+        if (deny && deny.length > 0 && deny.some(testSlackChannel)) {
+            return DenyReason.SLACK;
         }
 
         return DenyReason.ALLOWED;

--- a/src/IConfig.ts
+++ b/src/IConfig.ts
@@ -94,6 +94,10 @@ export interface IConfig {
         limits?: {
             team_count?: number;
             room_count?: number;
+        };
+        channel_adl?: {
+            allow: string[];
+            deny: string[];
         }
     };
 

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -31,6 +31,7 @@ export interface ITeamSyncConfig {
         whitelist?: string[];
         blacklist?: string[];
         alias_prefix?: string;
+        allow_private?: boolean;
     };
     users?: {
         enabled: boolean;
@@ -135,13 +136,19 @@ export class TeamSyncer {
         await queue.addAll(syncFunctionPromises);
     }
 
-    private getTeamSyncConfig(teamId: string, item?: "channel"|"user", itemId?: string) {
+    private getTeamSyncConfig(teamId: string, item?: "channel"|"user", itemId?: string, isPrivate = false) {
         const teamConfig = this.teamConfigs[teamId] || this.teamConfigs.all;
         if (!teamConfig) {
             return false;
         }
-        if (item === "channel" && (!teamConfig.channels || !teamConfig.channels.enabled)) {
-            return false;
+        if (item === "channel") {
+            if (!teamConfig.channels?.enabled) {
+                return false;
+            }
+            if (teamConfig.channels.allow_private === false) {
+                // Default to true.
+                return false;
+            }
         }
         if (item === "user" && (!teamConfig.users || !teamConfig.users.enabled)) {
             return false;
@@ -174,7 +181,7 @@ export class TeamSyncer {
     public async onDiscoveredPrivateChannel(teamId: string, client: WebClient, chanInfo: ConversationsInfoResponse) {
         log.info(`Discovered private channel ${teamId} ${chanInfo.channel.id}`);
         const channelItem = chanInfo.channel;
-        if (!this.getTeamSyncConfig(teamId, "channel", channelItem.id)) {
+        if (!this.getTeamSyncConfig(teamId, "channel", channelItem.id, true)) {
             log.info(`Not syncing`);
             return;
         }
@@ -245,7 +252,11 @@ export class TeamSyncer {
 
     private async syncChannel(teamId: string, channelItem: ConversationsInfo) {
         log.info(`Syncing channel ${teamId} ${channelItem.id}`);
-        if (!this.getTeamSyncConfig(teamId, "channel", channelItem.id)) {
+        if (!this.getTeamSyncConfig(teamId, "channel", channelItem.id, channelItem.is_private)) {
+            return;
+        }
+        if (this.main.allowDenyList.allowSlackChannel(channelItem.id, channelItem.name)) {
+            log.warn("Channel is not allowed to be bridged");
             return;
         }
 
@@ -352,6 +363,10 @@ export class TeamSyncer {
     private async bridgeChannelToNewRoom(teamId: string, channelItem: ConversationsInfo, client: WebClient) {
         const teamInfo = (await this.main.datastore.getTeam(teamId))!;
         log.info(`Attempting to dynamically bridge ${channelItem.id} ${channelItem.name}`);
+        if (this.main.allowDenyList.allowSlackChannel(channelItem.id, channelItem.name)) {
+            log.warn("Channel is not allowed to be bridged");
+        }
+
         const {user} = (await client.users.info({ user: teamInfo.user_id })) as UsersInfoResponse;
         try {
             const creatorClient = await this.main.clientFactory.getClientForSlackUser(teamId, channelItem.creator);


### PR DESCRIPTION
This allows us to A/D channels from being bridged across on startup or through the provisioner based on name or id.