### PR TITLE
Subscribe to additional events on the RTM API

### DIFF
--- a/changelog.d/477.bugfix
+++ b/changelog.d/477.bugfix
@@ -1,0 +1,1 @@
+Ensure that the bridge still syncs created and deleted channels, as well as new slack users, when using the RTM API.

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -100,7 +100,8 @@ export class SlackEventHandler extends BaseSlackHandler {
      * to events in order to handle them.
      */
     protected static SUPPORTED_EVENTS: string[] = ["message", "reaction_added", "reaction_removed",
-    "team_domain_change", "channel_rename", "user_change", "user_typing", "member_joined_channel"];
+    "team_domain_change", "channel_rename", "user_change", "user_typing", "member_joined_channel",
+    "channel_created", "channel_deleted", "team_join"];
     constructor(main: Main) {
         super(main);
     }


### PR DESCRIPTION
This ensures we still create and remove rooms for channels in realtime rather than during startup.