### PR TITLE
Do not reflect the bridge bot to Matrix

### DIFF
--- a/changelog.d/478.bugfix
+++ b/changelog.d/478.bugfix
@@ -1,0 +1,1 @@
+Do not join the Slack bot to the Matrix side

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -513,6 +513,11 @@ export class BridgedRoom {
         // 5 - Slack user has joined
         // 6 - Matrix user has joined
 
+        if (this.team?.user_id === slackId) {
+            // We never reflect our own slack bot.
+            return;
+        }
+
         const recipientPuppet = await this.main.clientFactory.getClientForSlackUser(this.slackTeamId!, slackId);
         const recipientGhost = await this.main.ghostStore.get(slackId, undefined, this.slackTeamId);
 


### PR DESCRIPTION
When the slack side bot joins the room, it gets reflected to Matrix. Since we never expect the bot to "speak" in the conversation, it's presence in the room is unwanted.