### PR TITLE
Small tweaks for puppeting code

### DIFF
--- a/changelog.d/482.bugfix
+++ b/changelog.d/482.bugfix
@@ -1,0 +1,1 @@
+Reduce chance of duplicate messages arriving on Matrix when using puppeting

--- a/src/AllowDenyList.ts
+++ b/src/AllowDenyList.ts
@@ -31,7 +31,7 @@ export class AllowDenyList {
             // Ensure the exact string matches.
             return new RegExp(`^${str}$`);
         }
-        // Otherwise, it's a real regex. Remove the leading and trailing /s
+        // Otherwise, it's a real regex. Remove the leading and trailing slash.
         return new RegExp(str.slice(1, str.length - 1));
     }
 

--- a/src/AllowDenyList.ts
+++ b/src/AllowDenyList.ts
@@ -31,8 +31,8 @@ export class AllowDenyList {
             // Ensure the exact string matches.
             return new RegExp(`^${str}$`);
         }
-        // Otherwise, it's a real regex
-        return new RegExp(str);
+        // Otherwise, it's a real regex. Remove the leading and trailing /s
+        return new RegExp(str.slice(1, str.length - 1));
     }
 
     private dmAllow?: {
@@ -83,7 +83,6 @@ export class AllowDenyList {
             (slackUsername && e.test(slackUsername)))) {
             return DenyReason.SLACK; // Slack user was not on the allow list
         }
-
         const deny = this.dmDeny;
         if (deny && deny.matrix?.length > 0 && deny.matrix.some((e) => e.test(matrixUser))) {
             return DenyReason.MATRIX; // Matrix user was on the deny list

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -589,7 +589,7 @@ export class BridgedRoom {
         await puppetedClient.conversations.invite({channel: this.slackChannelId!, users: ghost.slackId });
     }
 
-    public async onSlackMessage(message: ISlackMessageEvent, content?: Buffer) {
+    public async onSlackMessage(message: ISlackMessageEvent) {
         if (this.slackTeamId && message.user) {
             // This just checks if the user *could* be puppeted. If they are, delay handling their incoming messages.
             const hasPuppet = null !== await this.main.datastore.getPuppetTokenBySlackId(this.slackTeamId, message.user);
@@ -776,7 +776,7 @@ export class BridgedRoom {
         );
     }
 
-    private async handleSlackMessage(message: ISlackMessageEvent, ghost: SlackGhost, content?: Buffer) {
+    private async handleSlackMessage(message: ISlackMessageEvent, ghost: SlackGhost) {
         const eventTS = message.event_ts || message.ts;
         const channelId = this.slackChannelId!;
 

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -781,7 +781,7 @@ export class BridgedRoom {
     private async handleSlackMessage(message: ISlackMessageEvent, ghost: SlackGhost) {
         const eventTS = message.event_ts || message.ts;
         const channelId = this.slackChannelId!;
-        
+
         // Dedupe across RTM/Event streams
         this.addRecentSlackMessage(message.ts);
 

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -608,9 +608,9 @@ export class BridgedRoom {
             this.slackSendLock = this.slackSendLock.finally(async () => {
                 // Check again
                 if (!this.recentSlackMessages.includes(message.ts)) {
-                    // We sent this, ignore.
                     return this.handleSlackMessage(message, ghost);
                 }
+                // We sent this, ignore
             });
             await this.slackSendLock;
         } catch (err) {

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -966,7 +966,7 @@ export class Main {
         const entries = await this.datastore.getAllRooms();
         log.info(`Found ${entries.length} room entries in store`);
         await Promise.all(entries.map(async (entry, i) => {
-            log.info(`[${i}/${entries.length}] Loading room entry ${entry.matrix_id}`);
+            log.info(`[${i+1}/${entries.length}] Loading room entry ${entry.matrix_id}`);
             try {
                 await this.startupLoadRoomEntry(entry, joinedRooms as string[], teamClients);
             } catch (ex) {

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -712,7 +712,7 @@ export class Main {
                 "The admin of this Slack bridge has denied users to directly message this Slack user.",
                 msgtype: "m.notice",
             });
-            await intent.leave();
+            await intent.leave(roomId);
             return;
         }
 

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -315,24 +315,8 @@ export class SlackEventHandler extends BaseSlackHandler {
             return room.onSlackMessage(event);
         }
 
-        let content: Buffer|undefined;
-
-        if (msg.subtype === "file_share" && msg.file) {
-            // we need a user token to be able to enablePublicSharing
-            if (room.SlackClient) {
-                // TODO check is_public when matrix supports authenticated media
-                // https://github.com/matrix-org/matrix-doc/issues/701
-                try {
-                    msg.file = await this.enablePublicSharing(msg.file, room.SlackClient);
-                    content = await this.fetchFileContent(msg.file);
-                } catch {
-                    // Couldn't get a shareable URL for the file, oh well.
-                }
-            }
-        }
-
         msg.text = await this.doChannelUserReplacements(msg, msg.text!, room.SlackClient);
-        return room.onSlackMessage(msg, content);
+        return room.onSlackMessage(msg);
     }
 
     private async handleReaction(event: ISlackEventReaction, teamId: string) {

--- a/src/SlackHookHandler.ts
+++ b/src/SlackHookHandler.ts
@@ -351,14 +351,8 @@ export class SlackHookHandler extends BaseSlackHandler {
                 response.user_id,
                 response.access_token,
                 response.bot === undefined,
+                response.bot?.bot_access_token,
             );
-            if (response.bot) {
-                // Rather than upsert the values we were given, use the
-                // access token to validate and make additional requests
-                await this.main.clientFactory.upsertTeamByToken(
-                    response.bot.bot_access_token,
-                );
-            }
         } catch (err) {
             log.error("Error during handling of an oauth token:", err);
             return {

--- a/src/SlackHookHandler.ts
+++ b/src/SlackHookHandler.ts
@@ -300,7 +300,7 @@ export class SlackHookHandler extends BaseSlackHandler {
         // them by now
         PRESERVE_KEYS.forEach((k) => lookupRes.message[k] = params[k]);
         lookupRes.message.text = await this.doChannelUserReplacements(lookupRes.message, text, room.SlackClient);
-        return room.onSlackMessage(lookupRes.message, lookupRes.content);
+        return room.onSlackMessage(lookupRes.message);
     }
 
     private async handleAuthorize(token: string, params: qs.ParsedUrlQuery) {
@@ -378,7 +378,7 @@ export class SlackHookHandler extends BaseSlackHandler {
      *     formatted as a float.
      */
     private async lookupMessage(channelID: string, timestamp: string, client: WebClient): Promise<{
-        message: ISlackMessageEvent, content: Buffer|undefined}> {
+        message: ISlackMessageEvent}> {
         // Look up all messages at the exact timestamp we received.
         // This has microsecond granularity, so should return the message we want.
         const response = (await client.conversations.history({
@@ -405,17 +405,6 @@ export class SlackHookHandler extends BaseSlackHandler {
         const message = response.messages[0];
         log.debug("Looked up message from history as " + JSON.stringify(message));
 
-        if (message.subtype === "file_share") {
-            try {
-                message.file = await this.enablePublicSharing(message.file!, client);
-                const content = await this.fetchFileContent(message.file!);
-                return { message, content };
-            } catch (err) {
-                log.error("Failed to get file content: ", err);
-                // Fall through here and handle like a normal message.
-            }
-        }
-
-        return { message, content: undefined };
+        return { message };
     }
 }


### PR DESCRIPTION
Notably:

- Improve chances of catching duplicate messages when puppeting
- Fix issue where syncing a team for the first time will fail to sync channels or users
- Ensure ghosts will leave a PM room if they were blocked by a ADL.

Fixes #481 