### PR TITLE
Show flags in the help

### DIFF
--- a/changelog.d/520.feature
+++ b/changelog.d/520.feature
@@ -1,0 +1,1 @@
+The help command now distinguishes positional and named parameters.

--- a/src/AdminCommand.ts
+++ b/src/AdminCommand.ts
@@ -56,14 +56,18 @@ export class AdminCommand {
             const y = opts[b].demandOption;
             return (x === y) ? 0 : (x ? -1 : 1);
         }).map((key, i) => {
+            const positional = this.command.includes(` ${key}`) || this.command.includes(` [${key}]`);
+            if (positional) {
+                return null;
+            }
+
+            const placeholder = key.toUpperCase();
+            let strOpt = `--${key} ${placeholder}`;
             const opt = opts[key];
-            let strOpt = key;
             if (!opt.demandOption) {
                 strOpt = `[${strOpt}]`;
             }
-            if (this.command.includes(` ${key}`) || this.command.includes(` [${key}]`)) {
-                return null;
-            }
+
             // Spacing
             return (i === 0 ? " " : "") + strOpt;
         }).filter((n) => n !== null).join(" ");

--- a/src/tests/unit/AdminCommandTest.ts
+++ b/src/tests/unit/AdminCommandTest.ts
@@ -90,13 +90,13 @@ describe("AdminCommand", () => {
     describe("returns the simple help as expected", () => {
         it("when there are no options", () => {
             const command = new AdminCommand(
-                "help [command]",
+                "help",
                 "describes the commands available",
                 () => {},
             );
-            expect(command.simpleHelp()).to.equal("help [command] - describes the commands available");
+            expect(command.simpleHelp()).to.equal("help - describes the commands available");
         });
-        it("when there is an option", () => {
+        it("when there is a positional option", () => {
             const command = new AdminCommand(
                 "help [command]",
                 "describes the commands available",
@@ -110,9 +110,31 @@ describe("AdminCommand", () => {
             );
             expect(command.simpleHelp()).to.equal("help [command] - describes the commands available");
         });
+        it("when there is two types of options", () => {
+            const command = new AdminCommand(
+                "help [command]",
+                "describes the commands available",
+                () => {},
+                {
+                    command: {
+                        demandOption: false,
+                        description: "Get help about a particular command",
+                    },
+                    flag: {
+                        demandOption: false,
+                        description: "Some flag",
+                    },
+                    other_flag: {
+                        demandOption: true,
+                        description: "Some other flag",
+                    },
+                },
+            );
+            expect(commad.simpleHelp()).to.equal("help [command] --other_flag OTHER_FLAG [--flag FLAG] - describes the commands available");
+        });
         it("for the complex link command", () => {
             expect(LINK_COMMAND.simpleHelp()).to.equal(
-                "link room [channel_id] [slack_bot_token] [webhook_url] - connect a Matrix and a Slack room together"
+                "link --room ROOM [--channel_id CHANNEL_ID] [--slack_bot_token SLACK_BOT_TOKEN] [--webhook_url WEBHOOK_URL] - connect a Matrix and a Slack room together"
             );
         });
     });


### PR DESCRIPTION
`link room [channel_id] [slack_bot_token] [team_id] [webhook_url]`
becomes
`link --room ROOM [--channel_id CHANNEL_ID] [--slack_bot_token SLACK_BOT_TOKEN] [--team_id TEAM_ID] [--wbehook_url WEBHOOK_URL]`.

Without that it is impossible to tell which parameters are positional or not. I always fails once when trying to type a command.