### PR TITLE
WIP: End all emoji reactions on VS16

### DIFF
--- a/changelog.d/522.bugfix
+++ b/changelog.d/522.bugfix
@@ -1,0 +1,1 @@
+End all emoji reactions on VS16 in compliance with MSC2677

--- a/src/tests/unit/BridgedRoomTest.ts
+++ b/src/tests/unit/BridgedRoomTest.ts
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { BridgedRoom } from "../../BridgedRoom";
+import { expect } from "chai";
+import { BridgedRoom, emojifyReaction } from "../../BridgedRoom";
 
 describe("BridgedRoom", () => {
     it("constructs", () => {
@@ -23,5 +24,69 @@ describe("BridgedRoom", () => {
             matrix_room_id: "!abcde:localhost",
             slack_type: "unknown",
         });
+    });
+});
+
+describe("emojifyReaction", () => {
+    describe("Ends with Variant Selector 16", () => {
+        it("On former quick reactions", () => {
+            expect(emojifyReaction(':thumbsup:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':thumbsdown:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':rocket:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':heart:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':tada:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':eyes:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':smile:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':confused:')).to.match(/\ufe0f$/);
+        });
+        it("On other emojis", () => {
+            expect(emojifyReaction(':female-police-officer:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':male-singer:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':construction_worker:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':flag-ca:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':tm:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':electric_plug:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':clock430:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':metro:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':dog:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':woman-woman-boy-boy:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':mage:')).to.match(/\ufe0f$/);
+        });
+        it("On emoji sequences", () => {
+            expect(emojifyReaction(':male-farmer::skin-tone-2:')).to.match(/\ufe0f$/);
+            expect(emojifyReaction(':dancer::skin-tone-6:')).to.match(/\ufe0f$/);
+        });
+    });
+    describe("Doesn't contain a Variant Selector 16 other than at the end", () => {
+        it("On former quick reactions", () => {
+            expect(emojifyReaction(':thumbsup:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':thumbsdown:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':rocket:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':heart:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':tada:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':eyes:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':smile:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':confused:')).to.match(/^[^\ufe0f]*.$/);
+        });
+        it("On other emojis", () => {
+            expect(emojifyReaction(':female-police-officer:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':male-singer:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':construction_worker:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':flag-ca:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':tm:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':electric_plug:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':clock430:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':metro:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':dog:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':woman-woman-boy-boy:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':mage:')).to.match(/^[^\ufe0f]*.$/);
+        });
+        it("On emoji sequences", () => {
+            expect(emojifyReaction(':male-farmer::skin-tone-2:')).to.match(/^[^\ufe0f]*.$/);
+            expect(emojifyReaction(':dancer::skin-tone-6:')).to.match(/^[^\ufe0f]*.$/);
+        });
+    });
+    it("Returns the same string when no emoji with that name exists", () => {
+        expect(emojifyReaction(':notanemoji:')).to.equal(':notanemoji:');
     });
 });


### PR DESCRIPTION
This does not seem to be compatible with Element at the moment. Element does end some but not all emojis with VS16.

Also, as of today [MSC2677](https://github.com/matrix-org/matrix-doc/pull/2677) hasn't been merged.