### PR TITLE
Do not fail to bridge slack message if an alias doesn't exist

### DIFF
--- a/changelog.d/525.feature
+++ b/changelog.d/525.feature
@@ -1,0 +1,1 @@
+Fixed a bug where Slack messages would not bridge if a mentioned channel lacked an alias

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -171,11 +171,14 @@ export abstract class BaseSlackHandler {
             // If we bridge the room, attempt to look up its canonical alias.
             if (room !== undefined) {
                 const client = this.main.botIntent.getClient();
-                const canonical = await client.getStateEvent(room.MatrixRoomId, "m.room.canonical_alias");
-                if (canonical !== undefined && canonical.alias !== undefined) {
-                    text = text.slice(0, match.index) + canonical.alias + text.slice(match.index + match[0].length);
-                } else {
+                try {
+                    const canonical = await client.getStateEvent(room.MatrixRoomId, "m.room.canonical_alias");
+                    if (canonical !== undefined && canonical.alias !== undefined) {
+                        text = text.slice(0, match.index) + canonical.alias + text.slice(match.index + match[0].length);
+                    }
+                } catch (ex) {
                     // If we can't find a canonical alias fall back to just the Slack channel name.
+                    log.debug(`Room ${room.MatrixRoomId} does not have a canonical alias set.`);
                     room = undefined;
                 }
             }

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -171,14 +171,17 @@ export abstract class BaseSlackHandler {
             // If we bridge the room, attempt to look up its canonical alias.
             if (room !== undefined) {
                 const client = this.main.botIntent.getClient();
+                let canonicalAlias: string|undefined;
                 try {
                     const canonical = await client.getStateEvent(room.MatrixRoomId, "m.room.canonical_alias");
-                    if (canonical !== undefined && canonical.alias !== undefined) {
-                        text = text.slice(0, match.index) + canonical.alias + text.slice(match.index + match[0].length);
-                    }
+                    canonicalAlias = canonical?.alias;
                 } catch (ex) {
                     // If we can't find a canonical alias fall back to just the Slack channel name.
-                    log.debug(`Room ${room.MatrixRoomId} does not have a canonical alias set.`);
+                    log.debug(`Room ${room.MatrixRoomId} does not have a canonical alias`, ex);
+                }
+                if (canonicalAlias) {
+                    text = text.slice(0, match.index) + canonicalAlias + text.slice(match.index + match[0].length);
+                } else {
                     room = undefined;
                 }
             }


### PR DESCRIPTION
Fixes #524 