### PR TITLE
Hide typing from puppeted users

### DIFF
--- a/changelog.d/528.bugfix
+++ b/changelog.d/528.bugfix
@@ -1,0 +1,1 @@
+Hide typing notifications from puppeted users on Matrix

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -798,6 +798,11 @@ export class BridgedRoom {
     }
 
     public async onSlackTyping(event: ISlackEvent, teamId: string): Promise<void> {
+        const puppet = await this.main.datastore.getPuppetTokenBySlackId(teamId, event.user_id);
+        if (puppet) {
+            // Could be us, don't show typing
+            return;
+        }
         const ghost = await this.main.ghostStore.getForSlackMessage(event, teamId);
         await ghost.sendTyping(this.MatrixRoomId);
     }


### PR DESCRIPTION
If a puppeted user starts typing on Matrix, the bridge will currently reflect that as their remote user typing. We should hide the typing notifications for users we puppet.