### PR TITLE
Minimize docker build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,25 @@
 FROM node:14-alpine AS BUILD
-COPY . /src
 
 # git is needed to install Half-Shot/slackdown
 RUN apk add git
 WORKDIR /src
+
+COPY package.json package-lock.json /src/
 RUN npm install
+COPY . /src
 RUN npm run build
 
 FROM node:14-alpine
 
 VOLUME /data/ /config/
 
-COPY package.json /usr/src/app/
-COPY package-lock.json /usr/src/app/
+WORKDIR /usr/src/app
+COPY package.json package-lock.json /usr/src/app/
+RUN apk add git && npm install --only=production
 
 COPY --from=BUILD /src/config /usr/src/app/config
 COPY --from=BUILD /src/templates /usr/src/app/templates
 COPY --from=BUILD /src/lib /usr/src/app/lib
-
-WORKDIR /usr/src/app
-
-RUN apk add git && npm install --only=production
 
 EXPOSE 9898
 EXPOSE 5858

--- a/changelog.d/531.feature
+++ b/changelog.d/531.feature
@@ -1,0 +1,1 @@
+Allow docker to reuse cache when building the image by copying only npm related file before running `npm install`


### PR DESCRIPTION
We copy only npm related files first, so we can use the cache and not run again
`npm install` when only the code changes.

Signed-off-by: Alexandre Morignot <erdnaxeli@cervoi.se>

This speeds up a bit development time, when using the docker image to test (as I do).