### PR TITLE
Fix public rooms being created without aliases

### DIFF
--- a/changelog.d/544.bugfix
+++ b/changelog.d/544.bugfix
@@ -1,0 +1,1 @@
+Fixed a problem where automatically created rooms would not get an alias.

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1083,10 +1083,6 @@ export class Main {
                 });
             }, ONE_HOUR);
             await this.updateActivityMetrics();
-
-            // Send process stats again just to make the counters update sooner after
-            // startup
-            this.metrics.prometheus.refresh();
         }
         await puppetsWaiting;
         await teamSyncPromise;

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -491,7 +491,7 @@ export class TeamSyncer {
                 name: `#${channel.name}`,
                 topic,
                 visibility: isPublic ? "public" : "private",
-                room_alias: alias,
+                room_alias_name: alias,
                 preset: isPublic ? "public_chat" : "private_chat",
                 invite: inviteList,
                 initial_state: extraContent,

--- a/src/app.ts
+++ b/src/app.ts
@@ -39,6 +39,12 @@ const cli = new Cli({
         reg.setAppServiceToken(AppServiceRegistration.generateToken());
         reg.setSenderLocalpart("slackbot");
         reg.addRegexPattern("users", `@${config.username_prefix}.*:${config.homeserver.server_name}`, true);
+        const teamSyncEntries = config.team_sync && Object.values(config.team_sync) || [];
+        for (const teamEntry of teamSyncEntries) {
+            if (teamEntry.channels?.alias_prefix) {
+                reg.addRegexPattern("aliases", `#${teamEntry.channels?.alias_prefix}.*:${config.homeserver.server_name}`, true);
+            }
+        }
         callback(reg);
     },
     run: (cliPort: number, rawConfig: Record<string, undefined>|null, registration: any) => {


### PR DESCRIPTION
This was using the wrong option as pointed out by @MadLittleMods (https://gitlab.com/gitterHQ/webapp/-/merge_requests/2053).

We need to be careful here, because I can imagine making this work would introduce a breaking change insofar that if the aliases start working, the HS may reject the request because the registration file hasn't included the correct namespace.

The configuration to set aliases is behind a configuration flag, and I've ensured that generated registration files will include the correct alias prefixes.

