### PR TITLE
documentation: clarify upgrade instructions

### DIFF
--- a/changelog.d/545.doc
+++ b/changelog.d/545.doc
@@ -1,0 +1,1 @@
+Clarify upgrade steps in documentation. Contributed by Cameron Otsuka.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -129,6 +129,12 @@ To actually use it, you will need to configure some linked channels, see
 Once a Slack Workspace is connected, you can offer automatic hints on how
 to bridge existing and new channels by enabling [Workspace Sync](team_sync.md).
 
+## Upgrading
+1. Build the latest version of the application service. [Follow the Installation section instructions.](##Installation)
+1. Restart the application service.
+
+Note: You do NOT need to regenerate an appservice registration file.
+
 ## Proxying
 
 If you want to host this bridge on a different server than your homeserver, you will have

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -130,7 +130,7 @@ Once a Slack Workspace is connected, you can offer automatic hints on how
 to bridge existing and new channels by enabling [Workspace Sync](team_sync.md).
 
 ## Upgrading
-1. Build the latest version of the application service. [Follow the Installation section instructions.](##Installation)
+1. Build the latest version of the application service. [Follow the Installation section instructions.](#installation)
 1. Restart the application service.
 
 Note: You do NOT need to regenerate an appservice registration file.


### PR DESCRIPTION
I personally ran into an issue where I upgraded matrix-appservice-slack and didn't realize I should only rebuild and restart the appservice, not also generate a new appservice registration file, etc. This adds an Upgrading section to the documentation and identifies which steps to take specifically, with a note to NOT regenerate the registration file.