### PR TITLE
Fix metrics bug: Month has been off by one (e.g. January = 0)

### DIFF
--- a/changelog.d/553.bugfix
+++ b/changelog.d/553.bugfix
@@ -1,0 +1,1 @@
+Fix metrics bug: Month has been off by one (e.g. January = 0)

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -42,7 +42,7 @@ const pgp: IMain = pgInit({
 const log = Logging.get("PgDatastore");
 
 export class PgDatastore implements Datastore, ClientEncryptionStore {
-    public static readonly LATEST_SCHEMA = 10;
+    public static readonly LATEST_SCHEMA = 11;
     public readonly postgresDb: IDatabase<any>;
 
     constructor(connectionString: string) {

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -419,7 +419,7 @@ export class PgDatastore implements Datastore, ClientEncryptionStore {
             "INSERT INTO metrics_activities (user_id, room_id, date) " +
             "VALUES(${userId}, ${roomId}, ${date}) " +
             "ON CONFLICT ON CONSTRAINT cons_activities_unique DO NOTHING", {
-                date: `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`,
+                date: `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`,
                 roomId: room.toEntry().id,
                 userId,
             });

--- a/src/datastore/postgres/schema/v11.ts
+++ b/src/datastore/postgres/schema/v11.ts
@@ -4,7 +4,13 @@ export const runSchema = async (db: IDatabase<unknown>): Promise<void> => {
     // In 2020, when metrics_activities were introduced, there was a bug that caused
     // months to be zero-based (one number lower than expected).
     // https://github.com/matrix-org/matrix-appservice-slack/issues/552
+
+    // UNIQUE contraints cannot be deferred, so we drop it and re-add it after the migration.
     await db.none(`
+        ALTER TABLE metrics_activities DROP CONSTRAINT cons_activities_unique;
+    
         UPDATE metrics_activities set date = date + interval '1 month';
+        
+        ALTER TABLE metrics_activities ADD CONSTRAINT cons_activities_unique UNIQUE(user_id, room_id, date);
     `);
 };

--- a/src/datastore/postgres/schema/v11.ts
+++ b/src/datastore/postgres/schema/v11.ts
@@ -1,0 +1,10 @@
+import { IDatabase } from "pg-promise";
+
+export const runSchema = async (db: IDatabase<unknown>): Promise<void> => {
+    // In 2020, when metrics_activities were introduced, there was a bug that caused
+    // months to be zero-based (one number lower than expected).
+    // https://github.com/matrix-org/matrix-appservice-slack/issues/552
+    await db.none(`
+        UPDATE metrics_activities set date = date + interval '1 month';
+    `);
+};


### PR DESCRIPTION
Fixes #552

Fixes months to be zero-based and migrates old data.
This bug only affects our PostgreSQL adapter. Metrics are not supported by our NeDB adapter.