### PR TITLE
fix wrong config key name

### DIFF
--- a/changelog.d/566.doc
+++ b/changelog.d/566.doc
@@ -1,0 +1,1 @@
+Fix sample RTM config to use `log_level` key.

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -62,7 +62,7 @@ rtm:
 
   # Logging level specific to RTM traffic.
   #
-  logging: "silent"
+  log_level: "silent"
 
 # Port for incoming Slack requests from webhooks and event API messages
 # Optional if using RTM API, required otherwise.


### PR DESCRIPTION
according to the code and the spec it's supposed to be log_level instead of logging.
really annoying when you try to debug why RTM doesn't work and the setting is buggy itself :P