### PR TITLE
docs: tweaks install instructions re: port

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -51,7 +51,7 @@ ever stuck, you can post a question in the
 1. Create a new Matrix room to act as the administration control room. Note its
    internal room ID (Example: !abcdefg12345hijk:coolserver.com).
 
-1. Decide on a spare local TCP port number to use. It will listen for messages
+1. Decide on a spare local TCP port number to use. The Default is 5858.  It will listen for messages
    from Matrix and needs to be visible to the homeserver. Take care to configure
    firewalls appropriately. This port will be notated as `$MATRIX_PORT` in
    the remaining instructions.
@@ -66,9 +66,11 @@ ever stuck, you can post a question in the
   
   1. For `matrix_admin_room`, enter the internal room ID of the administration control
      room (Example: !abcdefg12345hijk:coolserver.com).
+  
+  1. For `homeserver.appservice_port`, specify the above $MATRIX_PORT if you would like to override
 
 1. Generate the appservice registration file. This will be used by the
-   Matrix homeserver. Here, you must specify the direct link the
+   Matrix homeserver. Here, you must specify the direct link (the field url) the
    **Matrix Homserver** can use to access the bridge, including the Matrix
    port it will send messages through (if this bridge runs on the same
    machine you can use `localhost` as the `$HOST` name):
@@ -78,7 +80,7 @@ ever stuck, you can post a question in the
    
 ```sh
 $ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack \ 
-    -r -c /config/config.yaml -u "http://$HOST:$MATRIX_PORT" -f /config/slack.yaml
+    -r -c /config/config.yaml -u "http://$HOST:$MATRIX_PORT" -f /config/slack-registration.yaml
 ```
 
 1. Start the actual application service:


### PR DESCRIPTION
Hi first of all thanks for this great life-saver project!

I installed this to my server recently, some feedback regarding the docs

my setup env:
- terraform to provision homeserver/this bridge
- docker-compose on ec2
- db: rds

## feedback re: port
- I spent sometime to understand the port to be used. It is more obvious when I read the log of runnable process and check the source code. According to 
https://github.com/matrix-org/matrix-appservice-slack/issues/436 the default port is 5858, shall we provide in the instruction as well? (as changed in this PR)
- I understand it is the port homeserver will connect to, while the name MATRIX_PORT sounds a port homeserver is listening to. Potentially HOMESERVER_PORT SYNAPSE_PORT are more specific?

- By "specify the direct link", and generating the config with docker, it might not be too obvious that if refers to the "url field" in the config yml when I decided to modify directly. (added a note in this PR)

- changed the file name as `slack-registration.yaml` is the recommended name, not `slack.yaml`
 
### /link
- Probably there are other issues pointing to this already. I was confused link to be a `/link` command and struggled when it didnt show up. There are nice feedback on the correctness of commands once the appservice is installed, so we can probably hint user to look for this to hint whether it is problem of appservice process or problem of access configurations. 

## some thoughts for terraform/docker-compose
- I found out https://github.com/spantaleev/matrix-docker-ansible-deploy only after I have done the deployment. Shall we add a link to that repo? 

- Will a sample terraform/ docker-compose sample of interest? There are some networking tweaks e.g. listen to `"http://appservice:5858"`  instead of localhost, tweaking the volumes mount point etc

