### PR TITLE
ProvisioningAPI.channelinfo: Differentiate between not found and not allowed

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1124,7 +1124,7 @@ export class Main {
         slackChannelId: string,
         teamId: string,
     ): Promise<ConversationsInfoResponse|'channel_not_allowed'|'channel_not_found'> {
-        let slackClient: WebClient|undefined;
+        let slackClient: WebClient;
         let teamEntry: TeamEntry|null = null;
 
         try {
@@ -1139,16 +1139,13 @@ export class Main {
             throw Error("Team ID provided, but no team found in database");
         }
 
-        let channelInfo: ConversationsInfoResponse | undefined;
-        if (slackClient) {
-            channelInfo = (await slackClient.conversations.info({ channel: slackChannelId })) as ConversationsInfoResponse;
-            if (!channelInfo.ok) {
-                if (channelInfo.error === 'channel_not_found') {
-                    return 'channel_not_found';
-                }
-                log.error(`conversations.info for ${slackChannelId} errored:`, channelInfo.error);
-                throw Error("Failed to get channel info");
+        const channelInfo = (await slackClient.conversations.info({ channel: slackChannelId })) as ConversationsInfoResponse;
+        if (!channelInfo.ok) {
+            if (channelInfo.error === 'channel_not_found') {
+                return 'channel_not_found';
             }
+            log.error(`conversations.info for ${slackChannelId} errored:`, channelInfo.error);
+            throw Error("Failed to get channel info");
         }
 
         if (this.allowDenyList.allowSlackChannel(slackChannelId, channelInfo?.channel.name) !== DenyReason.ALLOWED) {

--- a/src/Provisioning.ts
+++ b/src/Provisioning.ts
@@ -305,9 +305,13 @@ export class Provisioner {
         try {
             const channelInfo = await this.main.getChannelInfo(channelId, teamId);
 
-            if (!channelInfo) {
+            if (channelInfo === 'channel_not_found') {
                 return res.status(HTTP_CODES.NOT_FOUND).json({
-                    message: 'Slack channel not found or not allowed to be bridged',
+                    message: 'Slack channel not found',
+                });
+            } else if (channelInfo === 'channel_not_allowed') {
+                return res.status(HTTP_CODES.NOT_FOUND).json({
+                    message: 'Slack channel not not allowed to be bridged',
                 });
             }
 


### PR DESCRIPTION
I don't think we consider this to be confidential for Matrix users who have a puppet on the Slack server.