### PR TITLE
Config samples: Corrected rtm.logging to rtm.log_level; Schema: rtm.log_level: "off" -> "silent"

### DIFF
--- a/changelog.d/587.misc
+++ b/changelog.d/587.misc
@@ -1,1 +1,2 @@
 Config samples: Corrected rtm.logging to rtm.log_level
+rtm.log_level: "off" is not a valid value and should be "silent"

--- a/changelog.d/587.misc
+++ b/changelog.d/587.misc
@@ -1,0 +1,1 @@
+Config samples: Corrected rtm.logging to rtm.log_level

--- a/config/config.sample-complete.yaml
+++ b/config/config.sample-complete.yaml
@@ -19,7 +19,7 @@ tls:
 
 rtm:
   enable: true
-  logging: "silent"
+  log_level: "silent"
 
 slack_hook_port: 9898
 

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -62,7 +62,7 @@ rtm:
 
   # Logging level specific to RTM traffic.
   #
-  logging: "silent"
+  log_level: "silent"
 
 # Port for incoming Slack requests from webhooks and event API messages
 # Optional if using RTM API, required otherwise.

--- a/config/slack-config-schema.yaml
+++ b/config/slack-config-schema.yaml
@@ -33,7 +33,7 @@ properties:
         type: boolean
       log_level:
         type: "string"
-        enum: ["error", "warn", "info", "debug", "off"]
+        enum: ["error", "warn", "info", "debug", "silent"]
   db:
     type: object
     required: ["engine", "connectionString"]


### PR DESCRIPTION
Replaces #566 by fixing both config samples