### PR TITLE
Sync channels and users of a team independently

### DIFF
--- a/changelog.d/599.bugfix
+++ b/changelog.d/599.bugfix
@@ -1,0 +1,1 @@
+Sync channels and users of a Slack team independently, so that one failure does not cause the other to fail.

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1357,21 +1357,24 @@ export class Main {
         }
         if (!existingTeam && !puppeting && this.teamSyncer) {
             log.info("This is a new team, so syncing members and channels");
+            const team = await this.datastore.getTeam(teamId);
+            const teamClient = await this.clientFactory.getTeamClient(teamId);
+            if (!team) {
+                throw Error("Team does not exist AFTER upserting. This should't happen");
+            }
             try {
-                await this.teamSyncer.syncItems(
-                    teamId,
-                    await this.clientFactory.getTeamClient(teamId),
-                    "user",
+                await this.teamSyncer.syncUsers(
+                    team,
+                    teamClient,
                 );
             } catch (ex) {
                 log.warn("Failed to sync members", ex);
             }
 
             try {
-                await this.teamSyncer.syncItems(
+                await this.teamSyncer.syncChannels(
                     teamId,
-                    await this.clientFactory.getTeamClient(teamId),
-                    "channel",
+                    teamClient,
                 );
             } catch (ex) {
                 log.warn("Failed to sync channels", ex);

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -300,10 +300,11 @@ export class TeamSyncer {
         const config = this.getTeamSyncConfig(teamId, "channel", channelItem.id, channelItem.is_private);
         log.info(`Syncing channel ${teamId} ${channelItem.name} (${channelItem.id})`);
         if (!config) {
+            log.warn("Channel is not allowed to be bridged by the sync config");
             return;
         }
         if (this.main.allowDenyList.allowSlackChannel(channelItem.id, channelItem.name) !== DenyReason.ALLOWED) {
-            log.warn("Channel is not allowed to be bridged");
+            log.warn("Channel is not allowed to be bridged by the allow / deny list");
             return;
         }
 

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -81,8 +81,11 @@ export class TeamSyncer {
                 continue;
             }
             functionsForQueue.push(async () => {
-                log.info("Syncing team", teamId);
+                log.info("Syncing users for team", teamId);
                 await this.syncItems(teamId, client, "user");
+            });
+            functionsForQueue.push(async () => {
+                log.info("Syncing channels for team", teamId);
                 await this.syncItems(teamId, client, "channel");
             });
         }

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -86,7 +86,7 @@ export class TeamSyncer {
                 log.info(`Not syncing ${teamId}, no team configured in store`);
                 continue;
             }
-            functionsForQueue.push(async () => this.syncUsers(teamId, client, team));
+            functionsForQueue.push(async () => this.syncUsers(team, client));
             functionsForQueue.push(async () => this.syncChannels(teamId, client));
         }
         try {
@@ -99,10 +99,10 @@ export class TeamSyncer {
         }
     }
 
-    public async syncUsers(teamId: string, client: WebClient, team: TeamEntry): Promise<void> {
-        const teamConfig = this.getTeamSyncConfig(teamId, "user");
+    public async syncUsers(team: TeamEntry, client: WebClient): Promise<void> {
+        const teamConfig = this.getTeamSyncConfig(team.id, "user");
         if (!teamConfig) {
-            log.warn(`Not syncing userss for ${teamId}`);
+            log.warn(`Not syncing userss for ${team.id}`);
             return;
         }
         const itemList: ISlackUser[] = [];
@@ -128,7 +128,7 @@ export class TeamSyncer {
         log.info(`Found ${itemList.length} total users`);
         const queue = new PQueue({ concurrency: TEAM_SYNC_ITEM_CONCURRENCY });
         // .addAll waits for all promises to resolve.
-        await queue.addAll(itemList.map(item => this.syncUser.bind(this, teamId, team.domain, item)));
+        await queue.addAll(itemList.map(item => this.syncUser.bind(this, team.id, team.domain, item)));
     }
 
     public async syncChannels(teamId: string, client: WebClient): Promise<void> {


### PR DESCRIPTION
To avoid one throwing and taking out the other one. This PR also refactors the team syncer to split out users and channels to separate functions to make the code easier to follow and debug.