### PR TITLE
Make the team sync hint to channel admins configurable

### DIFF
--- a/changelog.d/601.feature
+++ b/changelog.d/601.feature
@@ -1,0 +1,1 @@
+Make the team sync hint to channel admins configurable

--- a/config/config.sample-complete.yaml
+++ b/config/config.sample-complete.yaml
@@ -47,6 +47,7 @@ team_sync:
       blacklist: ['CVCCPEY9X', 'C0108F9K37X']
       whitelist: []
       alias_prefix: "slack_"
+      hint_channel_admins: true
     users:
       enabled: true
   all:

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -130,6 +130,10 @@ slack_hook_port: 9898
   #     #
   #     #alias_prefix: "slack_"
   #
+  #     # Send a hint to channel admins how to invite matrix bridge if automatic join does not work
+  #     #
+  #     #hint_channel_admins: true
+  #
   #   # Should sync *all* team users to Matrix
   #   #
   #   users:


### PR DESCRIPTION
Since the hint how to invite the bridge could be not wanted there should
be a option to disable this. This commit introduce a simple boalean flag
which makes the message configuarable for users.

Signed-off-by: Jan Luca Naumann <j.naumann@fu-berlin.de>