### PR TITLE
Fallback to profile lookup if we don't have membership data for a user+room pair

### DIFF
--- a/changelog.d/628.bugfix
+++ b/changelog.d/628.bugfix
@@ -1,1 +1,1 @@
-Make sure we use correct displaynames and avatars on Slack even if we lost track of room state updates
+Improve reliability of Matrix users being bridged with correct displayname and avatar

--- a/changelog.d/628.bugfix
+++ b/changelog.d/628.bugfix
@@ -1,0 +1,1 @@
+Make sure we use correct displaynames and avatars on Slack even if we lost track of room state updates

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -486,7 +486,7 @@ export class BridgedRoom {
         const body: ISlackChatMessagePayload = {
             ...matrixToSlackResult,
             as_user: false,
-            username: user.getDisplaynameForRoom(message.room_id) || matrixToSlackResult.username,
+            username: await user.getDisplaynameForRoom(message.room_id) || matrixToSlackResult.username,
         };
         const text = body.text;
         if (!body.attachments && !text) {
@@ -505,7 +505,7 @@ export class BridgedRoom {
             }
         }
 
-        const avatarUrl = user.getAvatarUrlForRoom(message.room_id);
+        const avatarUrl = await user.getAvatarUrlForRoom(message.room_id);
 
         if (avatarUrl && avatarUrl.indexOf("mxc://") === 0) {
             body.icon_url = this.main.getUrlForMxc(avatarUrl);

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -486,7 +486,7 @@ export class BridgedRoom {
         const body: ISlackChatMessagePayload = {
             ...matrixToSlackResult,
             as_user: false,
-            username: await user.getDisplaynameForRoom(message.room_id) || matrixToSlackResult.username,
+            username: (await user.getDisplaynameForRoom(message.room_id)) || matrixToSlackResult.username,
         };
         const text = body.text;
         if (!body.attachments && !text) {

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -18,7 +18,7 @@ import {
     Bridge, BridgeBlocker, PrometheusMetrics, StateLookup,  StateLookupEvent,
     Logging, Intent, UserMembership, WeakEvent, PresenceEvent,
     AppService, AppServiceRegistration, UserActivityState, UserActivityTracker,
-    UserActivityTrackerConfig, MembershipQueue } from "matrix-appservice-bridge";
+    UserActivityTrackerConfig, MembershipQueue, UserProfile } from "matrix-appservice-bridge";
 import { Gauge, Counter } from "prom-client";
 import * as path from "path";
 import * as randomstring from "randomstring";
@@ -542,6 +542,10 @@ export class Main {
 
     public getStoredEvent(roomId: string, eventType: string, stateKey?: string): StateLookupEvent|StateLookupEvent[]|null|undefined {
         return this.stateStorage?.getState(roomId, eventType, stateKey);
+    }
+
+    public async getUserProfile(userId: string): Promise<UserProfile|undefined> {
+        return this.botIntent.matrixClient.getUserProfile(userId);
     }
 
     public async getState(roomId: string, eventType: string): Promise<any> {

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -545,7 +545,7 @@ export class Main {
     }
 
     public async getUserProfile(userId: string): Promise<UserProfile|undefined> {
-        return this.botIntent.matrixClient.getUserProfile(userId);
+        return this.botIntent.getProfileInfo(userId);
     }
 
     public async getState(roomId: string, eventType: string): Promise<any> {

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -18,7 +18,7 @@ import {
     Bridge, BridgeBlocker, PrometheusMetrics, StateLookup,  StateLookupEvent,
     Logging, Intent, UserMembership, WeakEvent, PresenceEvent,
     AppService, AppServiceRegistration, UserActivityState, UserActivityTracker,
-    UserActivityTrackerConfig, MembershipQueue, UserProfile } from "matrix-appservice-bridge";
+    UserActivityTrackerConfig, MembershipQueue } from "matrix-appservice-bridge";
 import { Gauge, Counter } from "prom-client";
 import * as path from "path";
 import * as randomstring from "randomstring";
@@ -542,10 +542,6 @@ export class Main {
 
     public getStoredEvent(roomId: string, eventType: string, stateKey?: string): StateLookupEvent|StateLookupEvent[]|null|undefined {
         return this.stateStorage?.getState(roomId, eventType, stateKey);
-    }
-
-    public async getUserProfile(userId: string): Promise<UserProfile|undefined> {
-        return this.botIntent.getProfileInfo(userId);
     }
 
     public async getState(roomId: string, eventType: string): Promise<any> {

--- a/src/MatrixUser.ts
+++ b/src/MatrixUser.ts
@@ -81,7 +81,7 @@ export class MatrixUser {
         const myMemberEvent = (this.main.getStoredEvent(
             roomId, "m.room.member", this.userId,
         ) as StateLookupEvent) as IMatrixMemberEvent;
-        let profile: IUserProfile|undefined = undefined; //myMemberEvent?.content;
+        let profile: IUserProfile|undefined = myMemberEvent?.content;
 
         if (!profile) {
             const cacheKey = `${roomId}:${this.userId}`;

--- a/src/MatrixUser.ts
+++ b/src/MatrixUser.ts
@@ -31,7 +31,7 @@ interface IMatrixMemberEvent {
 }
 
 const CACHED_PROFILE_MAX_AGE = 15 * 60 * 1000; // 15 minutes
-const CACHED_PROFILE_MAX_SIZE = 10_000; // 15 minutes
+const CACHED_PROFILE_MAX_SIZE = 10_000;
 
 const ROOM_PROFILE_CACHE = new QuickLRU<string, {
     profile: IUserProfile,

--- a/src/MatrixUser.ts
+++ b/src/MatrixUser.ts
@@ -1,4 +1,4 @@
-import { StateLookupEvent, UserProfile } from "matrix-appservice-bridge";
+import { Logging, StateLookupEvent, UserProfile } from "matrix-appservice-bridge";
 /*
 Copyright 2019 The Matrix.org Foundation C.I.C.
 
@@ -16,6 +16,8 @@ limitations under the License.
 */
 
 import { Main } from "./Main";
+
+const log = Logging.get("MatrixUser");
 
 /**
  * A Matrix event `m.room.member` indicating a user's presence in a room.
@@ -71,7 +73,11 @@ export class MatrixUser {
             roomId, "m.room.member", this.userId,
         ) as StateLookupEvent) as IMatrixMemberEvent;
 
-        return myMemberEvent?.content || await this.main.botIntent.getProfileInfo(this.userId);
+        return myMemberEvent?.content
+            || this.main.botIntent.getProfileInfo(this.userId).catch((err) => {
+                log.error(`Failed to load user ${this.userId} profile for ${roomId}:`, err);
+                return undefined;
+            });
     }
 
     public get aTime(): number|null {

--- a/src/MatrixUser.ts
+++ b/src/MatrixUser.ts
@@ -71,7 +71,7 @@ export class MatrixUser {
             roomId, "m.room.member", this.userId,
         ) as StateLookupEvent) as IMatrixMemberEvent;
 
-        return myMemberEvent?.content || await this.main.getUserProfile(this.userId);
+        return myMemberEvent?.content || await this.main.botIntent.getProfileInfo(this.userId);
     }
 
     public get aTime(): number|null {

--- a/tests/unit/MatrixUserTest.ts
+++ b/tests/unit/MatrixUserTest.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import { MatrixUser } from "../../src/MatrixUser";
 import { Main } from "../../src/Main";
 import { expect } from "chai";
-import QuickLRU from "@alloc/quick-lru";
 
 /**
  * Given an array of users, this function mocks `Main.getStoredEvent()` by
@@ -76,19 +75,6 @@ describe("MatrixUser", () => {
             const getUserProfile = async (userId) => Promise.resolve({ displayname: "Alice" });
             const user = new MatrixUser({ getStoredEvent, getUserProfile } as Main, { user_id: "@alice:localhost" });
             expect(await user.getDisplaynameForRoom("")).to.equal("Alice");
-        });
-        it("doesn't lookup the profile multiple times in short succession", async () => {
-            const getStoredEvent = getStoredEventGenerator([]);
-            let calls = 0;
-            const getUserProfile = async (userId) => {
-                calls++;
-                return Promise.resolve({ displayname: "Alice" })
-            };
-            const user = new MatrixUser({ getStoredEvent, getUserProfile } as Main, { user_id: "@alice:localhost" }, new QuickLRU({ maxSize: 1 }));
-            expect(await user.getDisplaynameForRoom("")).to.equal("Alice");
-            expect(calls).to.equal(1);
-            expect(await user.getDisplaynameForRoom("")).to.equal("Alice");
-            expect(calls).to.equal(1);
         });
         it("returns the displayName if one is given", async () => {
             const getStoredEvent = getStoredEventGenerator([

--- a/tests/unit/MatrixUserTest.ts
+++ b/tests/unit/MatrixUserTest.ts
@@ -76,6 +76,12 @@ describe("MatrixUser", () => {
             const user = new MatrixUser(mockMain(getStoredEvent), { user_id: "@alice:localhost" });
             expect(await user.getDisplaynameForRoom("")).to.equal("@alice:localhost");
         });
+        it("returns the user_id when profile cannot be obtained", async () => {
+            const getStoredEvent = getStoredEventGenerator([]);
+            const getProfileInfo = async () => Promise.reject('no');
+            const user = new MatrixUser(mockMain(getStoredEvent, getProfileInfo), { user_id: "@alice:localhost" });
+            expect(await user.getDisplaynameForRoom("")).to.equal("@alice:localhost");
+        });
         it("returns the profile displayName if state not available", async () => {
             const getStoredEvent = getStoredEventGenerator([]);
             const getProfileInfo = async (userId) => Promise.resolve({ displayname: "Alice" });
@@ -104,6 +110,12 @@ describe("MatrixUser", () => {
         it("returns undefined when no avatar is given", async () => {
             const getStoredEvent = getStoredEventGenerator([]);
             const user = new MatrixUser(mockMain(getStoredEvent), { user_id: "@alice:localhost" });
+            expect(await user.getAvatarUrlForRoom("")).to.be.undefined;
+        });
+        it("returns undefined when profile cannot be obtained", async () => {
+            const getStoredEvent = getStoredEventGenerator([]);
+            const getProfileInfo = async () => Promise.reject('no');
+            const user = new MatrixUser(mockMain(getStoredEvent, getProfileInfo), { user_id: "@alice:localhost" });
             expect(await user.getAvatarUrlForRoom("")).to.be.undefined;
         });
         it("returns the avatar_url if one is given", async () => {

--- a/tests/unit/MatrixUserTest.ts
+++ b/tests/unit/MatrixUserTest.ts
@@ -63,17 +63,23 @@ describe("MatrixUser", () => {
         });
     });
 
+    function mockMain(getStoredEvent: Function, getProfileInfo: any = async (userId) => undefined): Main {
+        return {
+            getStoredEvent,
+            botIntent: { getProfileInfo },
+        } as unknown as Main;
+    }
+
     describe("getDisplayName", () => {
         it("returns the user_id when no displayName is given", async () => {
             const getStoredEvent = getStoredEventGenerator([]);
-            const getUserProfile = async (userId) => undefined;
-            const user = new MatrixUser({ getStoredEvent, getUserProfile } as Main, { user_id: "@alice:localhost" });
+            const user = new MatrixUser(mockMain(getStoredEvent), { user_id: "@alice:localhost" });
             expect(await user.getDisplaynameForRoom("")).to.equal("@alice:localhost");
         });
         it("returns the profile displayName if state not available", async () => {
             const getStoredEvent = getStoredEventGenerator([]);
-            const getUserProfile = async (userId) => Promise.resolve({ displayname: "Alice" });
-            const user = new MatrixUser({ getStoredEvent, getUserProfile } as Main, { user_id: "@alice:localhost" });
+            const getProfileInfo = async (userId) => Promise.resolve({ displayname: "Alice" });
+            const user = new MatrixUser(mockMain(getStoredEvent, getProfileInfo), { user_id: "@alice:localhost" });
             expect(await user.getDisplaynameForRoom("")).to.equal("Alice");
         });
         it("returns the displayName if one is given", async () => {
@@ -81,7 +87,7 @@ describe("MatrixUser", () => {
                 { id: "@alice:localhost", displayName: "Alice" },
                 { displayName: "Hatmaker" },
             ]);
-            const user = new MatrixUser({ getStoredEvent } as Main, { user_id: "@alice:localhost" });
+            const user = new MatrixUser(mockMain(getStoredEvent), { user_id: "@alice:localhost" });
             expect(await user.getDisplaynameForRoom("")).to.equal("Alice");
         });
         it("returns 'displayName (userId)' if the display name isn't unique", async () => {
@@ -89,7 +95,7 @@ describe("MatrixUser", () => {
                 { displayName: "Alice" },
                 { id: "@alice:localhost", displayName: "Alice" },
             ]);
-            const user = new MatrixUser({ getStoredEvent } as Main, { user_id: "@alice:localhost" });
+            const user = new MatrixUser(mockMain(getStoredEvent), { user_id: "@alice:localhost" });
             expect(await user.getDisplaynameForRoom("")).to.equal("Alice (@alice:localhost)");
         });
     });
@@ -97,8 +103,7 @@ describe("MatrixUser", () => {
     describe("getAvatarUrlForRoom", () => {
         it("returns undefined when no avatar is given", async () => {
             const getStoredEvent = getStoredEventGenerator([]);
-            const getUserProfile = async (userId) => undefined;
-            const user = new MatrixUser({ getStoredEvent, getUserProfile } as Main, { user_id: "@alice:localhost" });
+            const user = new MatrixUser(mockMain(getStoredEvent), { user_id: "@alice:localhost" });
             expect(await user.getAvatarUrlForRoom("")).to.be.undefined;
         });
         it("returns the avatar_url if one is given", async () => {
@@ -106,8 +111,7 @@ describe("MatrixUser", () => {
                 { id: "@alice:localhost", avatarUrl: "https://localhost/alice.png" },
                 { id: "@hatmaker:localhost" },
             ]);
-            const getUserProfile = async (userId) => undefined;
-            const user = new MatrixUser({ getStoredEvent, getUserProfile } as Main, { user_id: "@alice:localhost" });
+            const user = new MatrixUser(mockMain(getStoredEvent), { user_id: "@alice:localhost" });
             expect(await user.getAvatarUrlForRoom("")).to.equal("https://localhost/alice.png");
         });
     });


### PR DESCRIPTION
Inspired by https://github.com/Half-Shot/matrix-appservice-discord/blob/develop/src/matrixeventprocessor.ts#L425, which we should probably integrate in MAB to not duplicate this logic everywhere.