### PR TITLE
Use debian for docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:16-bullseye-slim AS BUILD
 
 # git is needed to install Half-Shot/slackdown
-RUN apt update && apt install git
+RUN apt update && apt install -y git
 WORKDIR /src
 
 COPY package.json package-lock.json /src/
@@ -15,7 +15,7 @@ VOLUME /data/ /config/
 
 WORKDIR /usr/src/app
 COPY package.json package-lock.json /usr/src/app/
-RUN apt update && apt install git && npm ci --only=production --ignore-scripts
+RUN apt update && apt install git -y && npm ci --only=production --ignore-scripts
 
 COPY --from=BUILD /src/config /usr/src/app/config
 COPY --from=BUILD /src/templates /usr/src/app/templates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:16-alpine AS BUILD
+FROM node:16 AS BUILD
 
 # git is needed to install Half-Shot/slackdown
-RUN apk add git
+RUN apt update && apt install git
 WORKDIR /src
 
 COPY package.json package-lock.json /src/
@@ -9,13 +9,13 @@ RUN npm ci --ignore-scripts
 COPY . /src
 RUN npm run build
 
-FROM node:16-alpine
+FROM node:16
 
 VOLUME /data/ /config/
 
 WORKDIR /usr/src/app
 COPY package.json package-lock.json /usr/src/app/
-RUN apk add git && npm ci --only=production --ignore-scripts
+RUN apt update && apt install git && npm ci --only=production --ignore-scripts
 
 COPY --from=BUILD /src/config /usr/src/app/config
 COPY --from=BUILD /src/templates /usr/src/app/templates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 AS BUILD
+FROM node:16-bullseye-slim AS BUILD
 
 # git is needed to install Half-Shot/slackdown
 RUN apt update && apt install git
@@ -9,7 +9,7 @@ RUN npm ci --ignore-scripts
 COPY . /src
 RUN npm run build
 
-FROM node:16
+FROM node:16-bullseye-slim
 
 VOLUME /data/ /config/
 

--- a/changelog.d/645.misc
+++ b/changelog.d/645.misc
@@ -1,0 +1,1 @@
+Switch to using Debian as a base for Docker images.


### PR DESCRIPTION
Fixes #643 

This was due to alpine having funky DNS issues which led to lots of ENOTFOUND errors, we never truly got to the bottom of it but found that debian fixed the issue. The bridge doesn't rely on any particular operating system quirks so it's fine to just use the base debian image.