### PR TITLE
Fix inverted check if message was sent

### DIFF
--- a/changelog.d/648.bugfix
+++ b/changelog.d/648.bugfix
@@ -1,1 +1,1 @@
-Fix inverted check causing Slack messages to not be relayed to Matrix.
+Fix inverted check causing Slack messages to not be relayed to Matrix. Thanks to @ewilderj

--- a/changelog.d/648.bugfix
+++ b/changelog.d/648.bugfix
@@ -1,0 +1,1 @@
+Fix inverted check causing Slack messages to not be relayed to Matrix.

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -704,7 +704,7 @@ export class BridgedRoom {
             await ghost.cancelTyping(this.MatrixRoomId); // If they were typing, stop them from doing that.
             this.slackSendLock = this.slackSendLock.then(() => {
                 // Check again
-                if (!this.recentSlackMessages.includes(message.ts)) {
+                if (this.recentSlackMessages.includes(message.ts)) {
                     // We sent this, ignore
                     return;
                 }


### PR DESCRIPTION
Hey there @Half-Shot , this logic error was activated when the promise stuff was tidied up, and stops the bridge sending messages to the matrix room.