### PR TITLE
Only leave deleted users from rooms they are part of in Team Sync

### DIFF
--- a/changelog.d/649.bugfix
+++ b/changelog.d/649.bugfix
@@ -1,0 +1,1 @@
+Improve performance of removing deleted Slack users from rooms.

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -290,8 +290,9 @@ export class TeamSyncer {
         // XXX: We *should* fetch the rooms the user is actually in rather
         // than just removing it from every room. However, this is quicker to
         // implement.
-        log.info("Leaving from all rooms");
-        const teamRooms = this.main.rooms.getBySlackTeamId(teamId);
+        const joinedRooms = await slackGhost.intent.matrixClient.getJoinedRooms();
+        const teamRooms = this.main.rooms.getBySlackTeamId(teamId).filter(r => joinedRooms.includes(r.MatrixRoomId));
+        log.info(`Leaving ${slackGhost.matrixUserId} from ${teamRooms.length}`);
         let i = teamRooms.length;
         await Promise.all(teamRooms.map(async(r) =>
             this.main.membershipQueue.leave(r.MatrixRoomId, slackGhost.matrixUserId, { getId: () => slackGhost.matrixUserId }).catch(() => {

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -55,7 +55,6 @@ const TEAM_SYNC_FAILSAFE = 10;
  */
 export class TeamSyncer {
     private teamConfigs: {[teamId: string]: ITeamSyncConfig} = {};
-    private deletedUserQueue = new PQueue({ concurrency: TEAM_SYNC_DELETED_USER_CONCURRENCY });
     constructor(private main: Main) {
         const config = main.config;
         if (!config.team_sync) {

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -287,8 +287,8 @@ export class TeamSyncer {
         // Element does it by sending an empty string.
         // https://github.com/matrix-org/matrix-doc/issues/1674
         await slackGhost.intent.setAvatarUrl("");
-        const joinedRooms = await slackGhost.intent.matrixClient.getJoinedRooms();
-        const teamRooms = this.main.rooms.getBySlackTeamId(teamId).filter(r => joinedRooms.includes(r.MatrixRoomId));
+        const joinedRooms = new Set(await slackGhost.intent.matrixClient.getJoinedRooms());
+        const teamRooms = this.main.rooms.getBySlackTeamId(teamId).filter(r => joinedRooms.has(r.MatrixRoomId));
         log.info(`Leaving ${slackGhost.matrixUserId} from ${teamRooms.length} rooms`);
         let i = teamRooms.length;
         await Promise.all(teamRooms.map(async(r) =>

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -55,6 +55,7 @@ const TEAM_SYNC_FAILSAFE = 10;
  */
 export class TeamSyncer {
     private teamConfigs: {[teamId: string]: ITeamSyncConfig} = {};
+    private deletedUserQueue = new PQueue({ concurrency: TEAM_SYNC_DELETED_USER_CONCURRENCY });
     constructor(private main: Main) {
         const config = main.config;
         if (!config.team_sync) {
@@ -287,9 +288,6 @@ export class TeamSyncer {
         // Element does it by sending an empty string.
         // https://github.com/matrix-org/matrix-doc/issues/1674
         await slackGhost.intent.setAvatarUrl("");
-        // XXX: We *should* fetch the rooms the user is actually in rather
-        // than just removing it from every room. However, this is quicker to
-        // implement.
         const joinedRooms = await slackGhost.intent.matrixClient.getJoinedRooms();
         const teamRooms = this.main.rooms.getBySlackTeamId(teamId).filter(r => joinedRooms.includes(r.MatrixRoomId));
         log.info(`Leaving ${slackGhost.matrixUserId} from ${teamRooms.length}`);

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -289,7 +289,7 @@ export class TeamSyncer {
         await slackGhost.intent.setAvatarUrl("");
         const joinedRooms = await slackGhost.intent.matrixClient.getJoinedRooms();
         const teamRooms = this.main.rooms.getBySlackTeamId(teamId).filter(r => joinedRooms.includes(r.MatrixRoomId));
-        log.info(`Leaving ${slackGhost.matrixUserId} from ${teamRooms.length}`);
+        log.info(`Leaving ${slackGhost.matrixUserId} from ${teamRooms.length} rooms`);
         let i = teamRooms.length;
         await Promise.all(teamRooms.map(async(r) =>
             this.main.membershipQueue.leave(r.MatrixRoomId, slackGhost.matrixUserId, { getId: () => slackGhost.matrixUserId }).catch(() => {


### PR DESCRIPTION
Which should avoid the # of HTTP hits needed.