### PR TITLE
Remove uses of the deprecated JavaScript function substr()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -135,6 +135,11 @@ module.exports = {
                 "hoist": "all"
             }
         ],
+        "no-restricted-properties": [
+            "error",
+            { property: "substr", message: "Use .slice instead of .substr." },
+            { property: "substring", message: "Use .slice instead of .substring." }
+        ],
         "no-throw-literal": "warn",
         "no-trailing-spaces": "error",
         "no-undef-init": "error",

--- a/changelog.d/665.misc
+++ b/changelog.d/665.misc
@@ -1,0 +1,1 @@
+Remove uses of the deprecated JavaScript function substr()

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -974,7 +974,7 @@ export class BridgedRoom {
             let replyMEvent = await this.getReplyEvent(this.MatrixRoomId, message, this.SlackChannelId!);
             if (replyMEvent) {
                 replyMEvent = await this.stripMatrixReplyFallback(replyMEvent);
-                return await ghost.sendInThread(
+                return await ghost.sendWithReply(
                     this.MatrixRoomId, message.text, this.SlackChannelId!, eventTS, replyMEvent,
                 );
             } else {

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -289,7 +289,7 @@ export class BridgedRoom {
             emojiKeyName = relatesTo.key;
             // Strip the colons
             if (emojiKeyName.startsWith(":") && emojiKeyName.endsWith(":")) {
-                emojiKeyName = emojiKeyName.substring(1, emojiKeyName.length - 1);
+                emojiKeyName = emojiKeyName.slice(1, emojiKeyName.length - 1);
             }
         }
         const clientForRequest = await this.getClientForRequest(message.sender);
@@ -974,7 +974,7 @@ export class BridgedRoom {
             let replyMEvent = await this.getReplyEvent(this.MatrixRoomId, message, this.SlackChannelId!);
             if (replyMEvent) {
                 replyMEvent = await this.stripMatrixReplyFallback(replyMEvent);
-                return await ghost.sendWithReply(
+                return await ghost.sendInThread(
                     this.MatrixRoomId, message.text, this.SlackChannelId!, eventTS, replyMEvent,
                 );
             } else {

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -481,7 +481,7 @@ export class Main {
         } else if (this.config.homeserver.media_url) {
             baseUrl = this.config.homeserver.media_url;
         }
-        return `${baseUrl}/_matrix/media/r0/download/${mxcUrl.substring("mxc://".length)}`;
+        return `${baseUrl}/_matrix/media/r0/download/${mxcUrl.slice("mxc://".length)}`;
     }
 
     public async getTeamDomainForMessage(message: Record<string, unknown>, teamId?: string): Promise<string|undefined> {

--- a/src/OAuth2.ts
+++ b/src/OAuth2.ts
@@ -115,7 +115,7 @@ export class OAuth2 {
     public getPreauthToken(userId: string): string {
         // NOTE: We use 32 because we need to use it into SlackEventHandler which
         // expects inbound roomIds to be 32 chars.
-        const token = uuid().substring(0, INTERNAL_ID_LEN);
+        const token = uuid().slice(0, INTERNAL_ID_LEN);
         this.userTokensWaiting.set(token, {userId, expireAfter: TOKEN_EXPIRE_MS + Date.now()});
         return token;
     }

--- a/src/OAuth2.ts
+++ b/src/OAuth2.ts
@@ -115,7 +115,7 @@ export class OAuth2 {
     public getPreauthToken(userId: string): string {
         // NOTE: We use 32 because we need to use it into SlackEventHandler which
         // expects inbound roomIds to be 32 chars.
-        const token = uuid().substr(0, INTERNAL_ID_LEN);
+        const token = uuid().substring(0, INTERNAL_ID_LEN);
         this.userTokensWaiting.set(token, {userId, expireAfter: TOKEN_EXPIRE_MS + Date.now()});
         return token;
     }

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -312,27 +312,6 @@ export class SlackGhost {
         return Slackdown.parse(body);
     }
 
-    public async sendInThread(roomId: string, text: string, slackRoomId: string,
-        slackEventTs: string, replyEvent: IMatrixReplyEvent): Promise<void> {
-        const fallbackHtml = this.getFallbackHtml(roomId, replyEvent);
-        const fallbackText = this.getFallbackText(replyEvent);
-
-        const content = {
-            "m.relates_to": {
-                "rel_type": "io.element.thread",
-                "event_id": replyEvent.event_id,
-                "m.in_reply_to": {
-                    event_id: replyEvent.event_id,
-                },
-            },
-            "msgtype": "m.text", // for those who just want to send the reply as-is
-            "body": `${fallbackText}\n\n${this.prepareBody(text)}`,
-            "format": "org.matrix.custom.html",
-            "formatted_body": fallbackHtml + this.prepareFormattedBody(text),
-        };
-        await this.sendMessage(roomId, content, slackRoomId, slackEventTs);
-    }
-
     public async sendText(
         roomId: string,
         text: string,

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -312,6 +312,27 @@ export class SlackGhost {
         return Slackdown.parse(body);
     }
 
+    public async sendInThread(roomId: string, text: string, slackRoomId: string,
+        slackEventTs: string, replyEvent: IMatrixReplyEvent): Promise<void> {
+        const fallbackHtml = this.getFallbackHtml(roomId, replyEvent);
+        const fallbackText = this.getFallbackText(replyEvent);
+
+        const content = {
+            "m.relates_to": {
+                "rel_type": "io.element.thread",
+                "event_id": replyEvent.event_id,
+                "m.in_reply_to": {
+                    event_id: replyEvent.event_id,
+                },
+            },
+            "msgtype": "m.text", // for those who just want to send the reply as-is
+            "body": `${fallbackText}\n\n${this.prepareBody(text)}`,
+            "format": "org.matrix.custom.html",
+            "formatted_body": fallbackHtml + this.prepareFormattedBody(text),
+        };
+        await this.sendMessage(roomId, content, slackRoomId, slackEventTs);
+    }
+
     public async sendText(
         roomId: string,
         text: string,

--- a/src/SlackRTMHandler.ts
+++ b/src/SlackRTMHandler.ts
@@ -189,7 +189,7 @@ export class SlackRTMHandler extends SlackEventHandler {
 
     private createRtmClient(token: string, logLabel: string): RTMClient {
         const LOG_LEVELS = ["debug", "info", "warn", "error", "silent"];
-        const connLog = Logging.get(`RTM-${logLabel.substr(0, LOG_TEAM_LEN)}`);
+        const connLog = Logging.get(`RTM-${logLabel.substring(0, LOG_TEAM_LEN)}`);
         const logLevel = LOG_LEVELS.indexOf(this.main.config.rtm?.log_level || "silent");
         const rtm = new RTMClient(token, {
             logLevel: LogLevel.DEBUG, // We will filter this ourselves.

--- a/src/SlackRTMHandler.ts
+++ b/src/SlackRTMHandler.ts
@@ -189,7 +189,7 @@ export class SlackRTMHandler extends SlackEventHandler {
 
     private createRtmClient(token: string, logLabel: string): RTMClient {
         const LOG_LEVELS = ["debug", "info", "warn", "error", "silent"];
-        const connLog = Logging.get(`RTM-${logLabel.substring(0, LOG_TEAM_LEN)}`);
+        const connLog = Logging.get(`RTM-${logLabel.slice(0, LOG_TEAM_LEN)}`);
         const logLevel = LOG_LEVELS.indexOf(this.main.config.rtm?.log_level || "silent");
         const rtm = new RTMClient(token, {
             logLevel: LogLevel.DEBUG, // We will filter this ourselves.

--- a/src/rooms/UserAdminRoom.ts
+++ b/src/rooms/UserAdminRoom.ts
@@ -49,7 +49,7 @@ export class UserAdminRoom {
         }
         const args: string[] = ev.content.body.split(" ");
         const command = args[0].toLowerCase();
-        log.info(`${this.userId} sent admin message ${args[0].substring(32)}`);
+        log.info(`${this.userId} sent admin message ${args[0].slice(32)}`);
         if (command === "help") {
             return this.handleHelp();
         }

--- a/src/rooms/UserAdminRoom.ts
+++ b/src/rooms/UserAdminRoom.ts
@@ -49,7 +49,7 @@ export class UserAdminRoom {
         }
         const args: string[] = ev.content.body.split(" ");
         const command = args[0].toLowerCase();
-        log.info(`${this.userId} sent admin message ${args[0].substr(32)}`);
+        log.info(`${this.userId} sent admin message ${args[0].substring(32)}`);
         if (command === "help") {
             return this.handleHelp();
         }

--- a/src/scripts/migrateToPostgres.ts
+++ b/src/scripts/migrateToPostgres.ts
@@ -155,7 +155,7 @@ export const migrateFromNedb = async(nedb: NedbDatastore, targetDs: Datastore): 
         if (!user.slack_id || !user.team_id) {
             const localpart = user.id.split(":")[0];
             // XXX: we are making an assumption here that the prefix ends with _
-            const parts = localpart.substr(USER_PREFIX.length + 1).split("_"); // Remove any prefix.
+            const parts = localpart.substring(USER_PREFIX.length + 1).split("_"); // Remove any prefix.
             // If we encounter more parts than expected, the domain may be underscored
             while (parts.length > 2) {
                 parts[0] = `${parts.shift()}_${parts[0]}`;

--- a/src/scripts/migrateToPostgres.ts
+++ b/src/scripts/migrateToPostgres.ts
@@ -155,7 +155,7 @@ export const migrateFromNedb = async(nedb: NedbDatastore, targetDs: Datastore): 
         if (!user.slack_id || !user.team_id) {
             const localpart = user.id.split(":")[0];
             // XXX: we are making an assumption here that the prefix ends with _
-            const parts = localpart.substring(USER_PREFIX.length + 1).split("_"); // Remove any prefix.
+            const parts = localpart.slice(USER_PREFIX.length + 1).split("_"); // Remove any prefix.
             // If we encounter more parts than expected, the domain may be underscored
             while (parts.length > 2) {
                 parts[0] = `${parts.shift()}_${parts[0]}`;


### PR DESCRIPTION
`substr()` has been deprecated. For all the remaining uses in this code base `slice()` bahaves the same.