### PR TITLE
Fix: Don't create an internal ping room on every restart

### DIFF
--- a/changelog.d/669.bugfix
+++ b/changelog.d/669.bugfix
@@ -1,0 +1,1 @@
+Fix: Don't create an internal ping room on every restart

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1623,7 +1623,7 @@ export class Main {
             internalRoom = await this.datastore.getUserAdminRoom("-internal-");
             if (!internalRoom) {
                 internalRoom = (await this.bridge.getIntent().createRoom({ options: {}})).room_id;
-                await this.datastore.setUserAdminRoom(internalRoom, "-internal-");
+                await this.datastore.setUserAdminRoom("-internal-", internalRoom);
             }
             const time = await this.bridge.pingAppserviceRoute(internalRoom);
             log.info(`Successfully pinged the bridge. Round trip took ${time}ms`);


### PR DESCRIPTION
Because the parameters were swapped a new ping room is created on every bridge restart.

We don't include a cleanup of false entries as they are no harm and there hasn't been a stable release since this was introduced in PR #666.

Issue description: https://github.com/matrix-org/matrix-appservice-slack/pull/666/files#r818765045