### PR TITLE
Don't allow NULL in PostgreSQL columns of events

### DIFF
--- a/changelog.d/670.misc
+++ b/changelog.d/670.misc
@@ -1,0 +1,1 @@
+Don't allow NULL in SQL columns of events, matching the expectation of the models.

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -49,7 +49,7 @@ interface ClientSessionSchema {
 }
 
 export class PgDatastore implements Datastore, ClientEncryptionStore {
-    public static readonly LATEST_SCHEMA = 13;
+    public static readonly LATEST_SCHEMA = 14;
     public readonly postgresDb: IDatabase<any>;
 
     constructor(connectionString: string) {

--- a/src/datastore/postgres/schema/v14.ts
+++ b/src/datastore/postgres/schema/v14.ts
@@ -1,0 +1,12 @@
+import { IDatabase } from "pg-promise";
+
+export const runSchema = async(db: IDatabase<unknown>) => {
+    await db.none(`
+        ALTER TABLE events
+            ALTER COLUMN roomid SET NOT NULL,
+            ALTER COLUMN eventid SET NOT NULL,
+            ALTER COLUMN slackchannel SET NOT NULL,
+            ALTER COLUMN slackts SET NOT NULL,
+            ALTER COLUMN extras SET NOT NULL;
+    `);
+};

--- a/src/datastore/postgres/schema/v14.ts
+++ b/src/datastore/postgres/schema/v14.ts
@@ -2,6 +2,13 @@ import { IDatabase } from "pg-promise";
 
 export const runSchema = async(db: IDatabase<unknown>) => {
     await db.none(`
+        DELETE FROM events
+            WHERE
+                roomid = NULL OR
+                eventid = NULL OR
+                slackchannel = NULL OR
+                slackts = NULL OR
+                extras = NULL;
         ALTER TABLE events
             ALTER COLUMN roomid SET NOT NULL,
             ALTER COLUMN eventid SET NOT NULL,


### PR DESCRIPTION
The models expect all these values to be defined (not null). Allowing `NULL` for these columns in PostgreSQL is against the expected types of the `EventEntry`.

https://github.com/matrix-org/matrix-appservice-slack/blob/848c68c57fbfab62a2b05ccb4a0e99bbb3e3ff63/src/datastore/Models.ts#L44-L50

## Before
```
    Column    | Type | Collation | Nullable | Default 
--------------+------+-----------+----------+---------
 roomid       | text |           |          | 
 eventid      | text |           |          | 
 slackchannel | text |           |          | 
 slackts      | text |           |          | 
 extras       | text |           |          | 
Indexes:
    "cons_events_unique" UNIQUE CONSTRAINT, btree (eventid, roomid, slackchannel, slackts)
    "events_matrix_idx" btree (roomid, eventid)
    "events_slack_idx" btree (slackchannel, slackts)
```

## After
```
    Column    | Type | Collation | Nullable | Default 
--------------+------+-----------+----------+---------
 roomid       | text |           | not null | 
 eventid      | text |           | not null | 
 slackchannel | text |           | not null | 
 slackts      | text |           | not null | 
 extras       | text |           | not null | 
Indexes:
    "cons_events_unique" UNIQUE CONSTRAINT, btree (eventid, roomid, slackchannel, slackts)
    "events_matrix_idx" btree (roomid, eventid)
    "events_slack_idx" btree (slackchannel, slackts)
```
