### PR TITLE
Use the stable threads relations from MSC3440.

### DIFF
--- a/changelog.d/673.feature
+++ b/changelog.d/673.feature
@@ -1,0 +1,1 @@
+Support bridging Slack message threads with new m.thread relations (MSC3440)

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -1178,7 +1178,7 @@ export class BridgedRoom {
         if (!message.content) { return message.event_id; }
         if (!message.content["m.relates_to"]) { return message.event_id; }
         let parentEventId;
-        if (message.content["m.relates_to"].rel_type === "m.thread") {
+        if (["m.thread", "io.element.thread"].includes(message.content["m.relates_to"].rel_type)) {
             // Parent of a thread
             parentEventId = message.content["m.relates_to"].event_id;
         } else {

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -1178,7 +1178,7 @@ export class BridgedRoom {
         if (!message.content) { return message.event_id; }
         if (!message.content["m.relates_to"]) { return message.event_id; }
         let parentEventId;
-        if (message.content["m.relates_to"].rel_type === "io.element.thread") {
+        if (message.content["m.relates_to"].rel_type === "m.thread") {
             // Parent of a thread
             parentEventId = message.content["m.relates_to"].event_id;
         } else {

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -320,7 +320,7 @@ export class SlackGhost {
         slackEventTs: string, replyEvent: IMatrixReplyEvent): Promise<void> {
         const content = {
             "m.relates_to": {
-                "rel_type": "io.element.thread",
+                "rel_type": "m.thread",
                 // If the reply event is part of a thread, continue the thread.
                 // Otherwise, attach a thread to the reply event.
                 "event_id": replyEvent.content["m.relates_to"]?.event_id ?? replyEvent.event_id,


### PR DESCRIPTION
Fixes #673.

I don't know if any backwards compatibility is needed for the unstable ones added in #668, but I don't think that's seen a release yet, so I hope not?