### PR TITLE
Make towncrier build the news instead of printing its version

### DIFF
--- a/changelog.d/677.misc
+++ b/changelog.d/677.misc
@@ -1,0 +1,1 @@
+Fix towncrier script for summarising the newsfiles

--- a/scripts/towncrier.sh
+++ b/scripts/towncrier.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 VERSION=`python3 -c "import json; f = open('./package.json', 'r'); v = json.loads(f.read())['version']; f.close(); print(v)"`
-towncrier --version $VERSION $1
+towncrier build --version $VERSION $1


### PR DESCRIPTION
## Before
```
./scripts/towncrier.sh 
towncrier, version 21.9.0
```

## After
```
./scripts/towncrier.sh
Loading template...
Finding news fragments...
Rendering news fragments...
Writing to newsfile...
Staging newsfile...
Removing news fragments...
I want to remove the following files:
/home/jaller94/Git/matrix-appservice-slack/changelog.d/664.misc
…
```