### PR TITLE
Explicit that rtm.enabled needs to be set to true

### DIFF
--- a/docs/link_channels.md
+++ b/docs/link_channels.md
@@ -58,6 +58,8 @@ The Real Time Messaging (RTM) API is the newer and recommended way to use the br
       ```
       link --channel_id CHANNELID --room !the-matrix:room.id --slack_bot_token xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx
       ```
+      
+If messages get sent from Matrix to Slack, but not from Slack to Matrix, make sure that `rtm.enabled` is set to `true` in the `config.yaml` file.
 
 ## Webhooks
 


### PR DESCRIPTION
By default, `rtm` is not set and defaults to `false`. Debugging why messages don't land in Matrix from Slack can be _very_ confusing.