### PR TITLE
Add falling back to threads

### DIFF
--- a/changelog.d/709.bugfix
+++ b/changelog.d/709.bugfix
@@ -1,0 +1,1 @@
+Correctly set "is_falling_back" flag in thread events so that events in threads are not also displayed as replies.

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -324,6 +324,8 @@ export class SlackGhost {
                 // If the reply event is part of a thread, continue the thread.
                 // Otherwise, attach a thread to the reply event.
                 "event_id": replyEvent.content["m.relates_to"]?.event_id ?? replyEvent.event_id,
+                // Say that our reply is a thread fallback so clients that support threads can ignore it
+                "is_falling_back": true,
                 "m.in_reply_to": {
                     event_id: replyEvent.event_id,
                 },


### PR DESCRIPTION
This adds the flag to the thread which tells clients the reply is included as a fallback, this should stop slack threads displaying as replies in threads.

fixes #708