### PR TITLE
Fix admin commands getting stuck 

### DIFF
--- a/changelog.d/717.bugfix
+++ b/changelog.d/717.bugfix
@@ -1,0 +1,1 @@
+Prevent admin commands from being unusable after an invalid command is issued.

--- a/src/AdminCommand.ts
+++ b/src/AdminCommand.ts
@@ -14,39 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Options } from "yargs";
+import { Arguments, Options } from "yargs";
 
 export type ResponseCallback = (response: string) => void;
-interface IHandlerArgs {
-    matched: () =>  void;
+export interface IHandlerArgs {
     respond: ResponseCallback;
-    // yargs annoyingly puts the string parameters in with the more complex types
-    // above. To save lots of if|else|other types, unknown is being used here.
-    [key: string]: unknown;
 }
-type CommandCallback = (args: IHandlerArgs) => void|Promise<void>;
+type CommandCallback = (args: Arguments<IHandlerArgs>) => void|Promise<void>;
 
 export class AdminCommand {
     constructor(
         public readonly command: string,
         public readonly description: string,
-        private readonly cb: CommandCallback,
+        public readonly handler: CommandCallback,
         public readonly options: {[key: string]: Options}|null = null) {
-    }
-
-    public async handler(argv: IHandlerArgs): Promise<void> {
-        argv.matched();
-        try {
-            await this.cb(argv);
-        } catch (ex) {
-        }
     }
 
     /**
      * Returns a one-liner of how to use the command.
      * @returns A short description of the command
      */
-    public simpleHelp(): string {
+    public simpleHelp(): string|null {
+        if (!this.description) {
+            return null;
+        }
         const opts = this.options || {};
         const commandString = Object.keys(opts).sort((a, b) => {
             const x = opts[a].demandOption;
@@ -75,7 +66,10 @@ export class AdminCommand {
      * Returns a detailed description of the command and its options.
      * @returns An array of strings. Display each string in a separate line for the user.
      */
-    public detailedHelp(): string[] {
+    public detailedHelp(): string[]|null {
+        if (!this.description) {
+            return null;
+        }
         const response: string[] = [];
         response.push(`${this.command} - ${this.description}`);
         const opts = this.options || {};

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -927,20 +927,10 @@ export class Main {
             response.push(responseMsg);
         };
 
-        try {
-            // This will return true or false if the command matched.
-            const matched = await this.adminCommands.parse(cmd, respond);
-            if (!matched) {
-                log.debug(`Unrecognised command "${cmd}"`);
-                respond(`Unrecognised command "${cmd}"`);
-            } else if (response.length === 0) {
-                respond("Done");
-            }
-        } catch (ex) {
-            const error = ex as {message: string; name?: "YError"};
-            log.warn(`Command '${cmd}' failed to complete:`, ex);
-            // YErrors are yargs errors when the user inputs the command wrong.
-            respond(`${error.name === "YError" ? error.message : "Command failed: See the logs for details."}`);
+        const waiter = this.adminCommands.parse(cmd, respond, ev.sender);
+        await waiter;
+        if (response.length === 0) {
+            respond("Done");
         }
 
         const message = response.join("\n");


### PR DESCRIPTION
The two main reasons why admin commands got stuck are:
1. Calling [`yargs.parse`](https://yargs.js.org/docs/#api-reference-parseargs-context-parsecallback) multiple times apparently doesn't behave well when command handlers return a Promise:
> Note: parse() should be called only once when [command()](https://yargs.js.org/docs/#command) is called with a handler returning a promise. If your use case requires parse() to be called several times, any asynchronous operation performed in a command handler should not result in the handler returning a promise.
2. When `yargs.parse` throws, or the callback given to it throws, `yargs.argv` is permanently set to a `YError`, and all future calls to `yargs.parse` throw that same error.

This PR cleans up some of our `yargs` usage & moves all asynchronicity of command callbacks outside of `yargs.parse`.