### PR TITLE
Docs: Fixed numbering by fixing indentation

### DIFF
--- a/changelog.d/719.bugfix
+++ b/changelog.d/719.bugfix
@@ -1,0 +1,1 @@
+Docs: Fixed numbering by fixing indentation

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -75,10 +75,10 @@ ever stuck, you can post a question in the
     `$ yarn start -r -c config/config.yaml -u "http://$HOST:$MATRIX_PORT"`
    or with docker:
    
-```sh
-$ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack \ 
-    -r -c /config/config.yaml -u "http://$HOST:$MATRIX_PORT" -f /config/slack-registration.yaml
-```
+   ```sh
+   $ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack \ 
+       -r -c /config/config.yaml -u "http://$HOST:$MATRIX_PORT" -f /config/slack-registration.yaml
+   ```
 
 1. Start the actual application service:
 
@@ -91,11 +91,11 @@ $ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack \
    homeserver. Add the registration file to your homeserver config (default
    `homeserver.yaml`):
    
-```yaml
-app_service_config_files:
-    - ...
-    - "/path/to/slack-registration.yaml"
-```
+   ```yaml
+   app_service_config_files:
+       - ...
+       - "/path/to/slack-registration.yaml"
+   ```
 
    Don't forget - it has to be a YAML list of strings, not just a single string.
 


### PR DESCRIPTION
The original page stopped numbering at #7 then started with #1 again. The sole cause was that the indentation of the code blocks was incorrect. By fixing the indentation of the code blocks, the numbering now correctly goes 7, 8, 9, 10.