### PR TITLE
Invite own ghost in DMs if needed

### DIFF
--- a/changelog.d/722.bugfix
+++ b/changelog.d/722.bugfix
@@ -1,0 +1,1 @@
+Ensure messages you send in a DM from Slack will appear in Matrix, even if the ghost of your Slack account was not initially present in the Matrix DM room.


### PR DESCRIPTION
Inviting a Slack ghost to a DM won't invite the ghost for your own Slack user, meaning that messages you send in that DM from Slack can only be bridged if your Slack ghost is in the Matrix DM.  This PR ensures that your Slack ghost gets invited when you send a message in Slack.