### PR TITLE
Handle admin command errors

### DIFF
--- a/changelog.d/725.bugfix
+++ b/changelog.d/725.bugfix
@@ -1,0 +1,1 @@
+Safely handle errors from admin commands.

--- a/src/AdminCommand.ts
+++ b/src/AdminCommand.ts
@@ -20,6 +20,7 @@ export type ResponseCallback = (response: string) => void;
 export interface IHandlerArgs {
     respond: ResponseCallback;
     resolve: () => void;
+    reject: (error: any) => void;
 }
 type CommandCallback = (args: Arguments<IHandlerArgs>) => void|Promise<void>;
 
@@ -32,7 +33,7 @@ export class AdminCommand {
     }
 
     public handler(argv: Arguments<IHandlerArgs>): void {
-        void Promise.resolve(this.cb(argv)).finally(argv.resolve);
+        void Promise.resolve(this.cb(argv)).then(argv.resolve, argv.reject);
     }
 
     /**

--- a/src/AdminCommands.ts
+++ b/src/AdminCommands.ts
@@ -407,10 +407,12 @@ export class AdminCommands {
         const currCommandWaiter = new Promise<void>((resolve, reject) => {
             const prevCommandWaiter = this.latestCommandWaiterForSender.get(sender) ?? Promise.resolve();
             void prevCommandWaiter.finally(() => {
-                this.yargs.parseSync(argv, {
+                const context: IHandlerArgs = {
                     respond,
                     resolve,
-                }, (error) => {
+                    reject,
+                };
+                this.yargs.parseSync(argv, context, (error) => {
                     if (error) {
                         // NOTE: Throwing here makes yargs.argv get stuck on an error object, so reject instead
                         reject(error);

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1006,8 +1006,7 @@ export class Main {
             }
         } catch (ex) {
             log.warn(`Command '${cmd}' failed to complete:`, ex);
-            // YErrors are yargs errors when the user inputs the command wrong.
-            respond(`${ex instanceof Error && ex.name === "YError" ? ex.message : "Command failed: See the logs for details."}`);
+            respond(`${ex instanceof Error ? ex.message : "Command failed: See the logs for details."}`);
         }
 
         const message = response.join("\n");


### PR DESCRIPTION
Fixes #724

The crash caused by this kind of admin command errors is a regression in 2.0.2-rc1, but in 2.0.1, they would be ignored & the bridge bot would just say "Done".