### PR TITLE
Revert "Docs: Run bridge as daemon"

### DIFF
--- a/changelog.d/720.misc
+++ b/changelog.d/720.misc
@@ -1,1 +1,0 @@
-Docs: Adapt code example to run the Docker container as a daemon.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -85,7 +85,7 @@ $ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack \
     `$ yarn start -c config/config.yaml -p $MATRIX_PORT`
    or with docker:
    
-    `$ docker run -d -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack`
+    `$ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack`
 
 1. Copy the newly-generated `slack-registration.yaml` file to your Matrix
    homeserver. Add the registration file to your homeserver config (default


### PR DESCRIPTION
Reverts matrix-org/matrix-appservice-slack#720

This should have been merged into `develop`.