### PR TITLE
Correctly attribute mkarg for past contributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ Bugfixes
 Internal Changes
 ----------------
 
-- Docs: Consistently call the registration file slack-registration.yaml. ([\#551](https://github.com/matrix-org/matrix-appservice-slack/issues/551))
 - Docs: Docker container uses port 5858 unless explicitly modified in config.yaml ([\#718](https://github.com/matrix-org/matrix-appservice-slack/issues/718)). Contributed by @mkarg
 - Docs: Fixed numbering by fixing indentation ([\#719](https://github.com/matrix-org/matrix-appservice-slack/issues/719)). Contributed by @mkarg
 - Docs: Run bridge as daemon ([\#720](https://github.com/matrix-org/matrix-appservice-slack/issues/720)). Contributed by @mkarg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ Internal Changes
 ----------------
 
 - Docs: Consistently call the registration file slack-registration.yaml. ([\#551](https://github.com/matrix-org/matrix-appservice-slack/issues/551))
-- Docs: Clarify default port, fix indents and reduce abbreviations. ([\#727](https://github.com/matrix-org/matrix-appservice-slack/issues/727))
+- Docs: Docker container uses port 5858 unless explicitly modified in config.yaml ([\#718](https://github.com/matrix-org/matrix-appservice-slack/issues/718)). Contributed by @mkarg
+- Docs: Fixed numbering by fixing indentation ([\#719](https://github.com/matrix-org/matrix-appservice-slack/issues/719)). Contributed by @mkarg
+- Docs: Run bridge as daemon ([\#720](https://github.com/matrix-org/matrix-appservice-slack/issues/720)). Contributed by @mkarg
+- Docs: Merge #718, #719 and #720 and reduce abbreviations. ([\#727](https://github.com/matrix-org/matrix-appservice-slack/issues/727))
 
 
 2.0.2-rc1 (2022-11-28)

--- a/changelog.d/729.misc
+++ b/changelog.d/729.misc
@@ -1,0 +1,1 @@
+Correctly attribute mkarg for documentation contributions. We also reverted commits and recommited them with the correct Author value set.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -75,10 +75,10 @@ ever stuck, you can post a question in the
     `$ yarn start -r -c config/config.yaml -u "http://$HOST:$MATRIX_PORT"`
    or with docker:
    
-   ```sh
-   $ docker run --volume /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack \ 
-      -r -c /config/config.yaml -u "http://$HOST:$MATRIX_PORT" -f /config/slack-registration.yaml
-   ```
+```sh
+$ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack \ 
+    -r -c /config/config.yaml -u "http://$HOST:$MATRIX_PORT" -f /config/slack-registration.yaml
+```
 
 1. Start the actual application service:
 
@@ -95,11 +95,11 @@ ever stuck, you can post a question in the
    homeserver. Add the registration file to your homeserver config (default
    `homeserver.yaml`):
    
-   ```yaml
-    app_service_config_files:
-      - ...
-      - "/path/to/slack-registration.yaml"
-   ```
+```yaml
+app_service_config_files:
+    - ...
+    - "/path/to/slack-registration.yaml"
+```
 
    Don't forget - it has to be a YAML list of strings, not just a single string.
 
@@ -110,9 +110,9 @@ ever stuck, you can post a question in the
    respond to commands. The bot's user ID is formed from the `sender_localpart`
    field of the registration file, and the homeserver's domain name. For example:
 
-   ```
-   /invite @slackbot:my.server.here
-   ```
+    ```
+    /invite @slackbot:my.server.here
+    ```
 
 NOTE: At the time of writing, Element does not recognize the Slack bot. This is
 okay. The bot *is there*. If Element asks if you're sure you want to invite

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -91,7 +91,7 @@ ever stuck, you can post a question in the
    or with docker:
    
    ```ssh
-   $ docker run -d --volume /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack
+   $ docker run --detach --volume /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack
    ```
 
 1. Copy the newly-generated `slack-registration.yaml` file to your Matrix

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -53,7 +53,7 @@ ever stuck, you can post a question in the
 1. Decide on a spare local TCP port number to use. It will listen for messages
    from Matrix and needs to be visible to the homeserver. Take care to configure
    firewalls appropriately. This port will be notated as `$MATRIX_PORT` in
-   the remaining instructions. By default, this is 5858.
+   the remaining instructions.
 
 1. Create a `config/config.yaml` file for global configuration. There is a sample
    one to begin with in `config/config.sample.yaml`. You should copy and
@@ -65,9 +65,6 @@ ever stuck, you can post a question in the
   
   1. For `matrix_admin_room`, enter the internal room ID of the administration control
      room (Example: !abcdefg12345hijk:coolserver.com).
-
-  1. When using bridge in Docker container: For `appservice_port`, enter the value of
-     `$MATRIX_PORT`, unless it is `5858`, which is the default.
 
 1. Generate the appservice registration file. This will be used by the
    Matrix homeserver. Here, you must specify the direct link the

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -78,10 +78,10 @@ ever stuck, you can post a question in the
     `$ yarn start -r -c config/config.yaml -u "http://$HOST:$MATRIX_PORT"`
    or with docker:
    
-```sh
-$ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack \ 
-    -r -c /config/config.yaml -u "http://$HOST:$MATRIX_PORT" -f /config/slack-registration.yaml
-```
+   ```sh
+   $ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack \ 
+      -r -c /config/config.yaml -u "http://$HOST:$MATRIX_PORT" -f /config/slack-registration.yaml
+   ```
 
 1. Start the actual application service:
 
@@ -98,11 +98,11 @@ $ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack \
    homeserver. Add the registration file to your homeserver config (default
    `homeserver.yaml`):
    
-```yaml
-app_service_config_files:
-    - ...
-    - "/path/to/slack-registration.yaml"
-```
+   ```yaml
+   app_service_config_files:
+      - ...
+      - "/path/to/slack-registration.yaml"
+   ```
 
    Don't forget - it has to be a YAML list of strings, not just a single string.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -91,7 +91,7 @@ ever stuck, you can post a question in the
    or with docker:
    
    ```ssh
-   $ docker run --volume /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack
+   $ docker run -d --volume /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack
    ```
 
 1. Copy the newly-generated `slack-registration.yaml` file to your Matrix

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -53,7 +53,7 @@ ever stuck, you can post a question in the
 1. Decide on a spare local TCP port number to use. It will listen for messages
    from Matrix and needs to be visible to the homeserver. Take care to configure
    firewalls appropriately. This port will be notated as `$MATRIX_PORT` in
-   the remaining instructions.
+   the remaining instructions. By default, this is 5858.
 
 1. Create a `config/config.yaml` file for global configuration. There is a sample
    one to begin with in `config/config.sample.yaml`. You should copy and
@@ -65,6 +65,9 @@ ever stuck, you can post a question in the
   
   1. For `matrix_admin_room`, enter the internal room ID of the administration control
      room (Example: !abcdefg12345hijk:coolserver.com).
+
+  1. When using bridge in Docker container: For `appservice_port`, enter the value of
+     `$MATRIX_PORT`, unless it is `5858`, which is the default.
 
 1. Generate the appservice registration file. This will be used by the
    Matrix homeserver. Here, you must specify the direct link the

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -79,7 +79,7 @@ ever stuck, you can post a question in the
    or with docker:
    
    ```sh
-   $ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack \ 
+   $ docker run --volume /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack \ 
       -r -c /config/config.yaml -u "http://$HOST:$MATRIX_PORT" -f /config/slack-registration.yaml
    ```
 
@@ -91,7 +91,7 @@ ever stuck, you can post a question in the
    or with docker:
    
    ```ssh
-   $ docker run -volume /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack
+   $ docker run --volume /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack
    ```
 
 1. Copy the newly-generated `slack-registration.yaml` file to your Matrix
@@ -113,9 +113,9 @@ ever stuck, you can post a question in the
    respond to commands. The bot's user ID is formed from the `sender_localpart`
    field of the registration file, and the homeserver's domain name. For example:
 
-    ```
-    /invite @slackbot:my.server.here
-    ```
+   ```
+   /invite @slackbot:my.server.here
+   ```
 
 NOTE: At the time of writing, Element does not recognize the Slack bot. This is
 okay. The bot *is there*. If Element asks if you're sure you want to invite

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -99,7 +99,7 @@ ever stuck, you can post a question in the
    `homeserver.yaml`):
    
    ```yaml
-   app_service_config_files:
+    app_service_config_files:
       - ...
       - "/path/to/slack-registration.yaml"
    ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -88,7 +88,7 @@ $ docker run -v /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack \
    or with docker:
    
    ```ssh
-   $ docker run --detach --volume /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack
+   $ docker run -volume /path/to/config/:/config/ matrixdotorg/matrix-appservice-slack
    ```
 
 1. Copy the newly-generated `slack-registration.yaml` file to your Matrix


### PR DESCRIPTION
The original PRs were closed because we deleted the branch which they were filed against.
GitHub didn't allow me to reopen them and point them against the `develop` branch.

In the interest of not spending much time on the changes, I copied the changes into a new PR. This left mkarg without an attribution in the Git history and release notes.

This PR tries to rectify the mistake by re-commiting the changes with a changed `Author` for the Git history and changes to the CHANGELOG.