### PR TITLE
Optimize Dockerfile for rebuilds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,20 @@ FROM node:18-bullseye-slim AS BUILD
 RUN apt update && apt install -y git
 WORKDIR /src
 
-COPY package.json /src/
+COPY package.json yarn.lock /src/
+
+RUN yarn --ignore-scripts --pure-lockfile --network-timeout 600000
+
 COPY . /src
-RUN yarn --pure-lockfile --network-timeout 600000
+
+RUN yarn build
 
 FROM node:18-bullseye-slim
 
 VOLUME /data/ /config/
 
 WORKDIR /usr/src/app
-COPY package.json /usr/src/app/
+COPY package.json yarn.lock /usr/src/app/
 RUN apt update && apt install git -y && yarn --network-timeout 600000 --production --pure-lockfile && yarn cache clean
 
 COPY --from=BUILD /src/config /usr/src/app/config

--- a/changelog.d/732.misc
+++ b/changelog.d/732.misc
@@ -1,0 +1,1 @@
+Optimize the Dockerfile to speed up image rebuilds following a code change.


### PR DESCRIPTION
Optimizes Docker image rebuilds following a code change by installing dependencies first, then copying over code.
This speeds up rebuilds by not having to install the dependencies every time since this layer will remain cached.