### PR TITLE
Update matrix-appservice-bridge

### DIFF
--- a/changelog.d/740.misc
+++ b/changelog.d/740.misc
@@ -1,0 +1,1 @@
+Update matrix-appservice-bridge to `8.1.1`.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "axios": "^0.27.2",
     "classnames": "^2.3.2",
     "escape-string-regexp": "^4.0.0",
-    "matrix-appservice-bridge": "^8.1.0",
+    "matrix-appservice-bridge": "^8.1.1",
     "matrix-widget-api": "^1.1.1",
     "minimist": "^1.2.6",
     "nedb": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3096,10 +3096,10 @@ make-error@^1.1.1:
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
-matrix-appservice-bridge@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/matrix-appservice-bridge/-/matrix-appservice-bridge-8.1.0.tgz#9f12ae6de3de290c129339f308fea9dae28cc8eb"
-  integrity sha512-yeBXFOo9Iz0lw5kTAMpZPWvKRe+O7g0VN+CI7YB7/jPFINIQ5IA71OIxnrNoBMX7GO5+Ku+n7HX0XA+25uJ7FQ==
+matrix-appservice-bridge@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/matrix-appservice-bridge/-/matrix-appservice-bridge-8.1.1.tgz#9bf37d39742aed276e01d01e5c28c75d7ba1fcf7"
+  integrity sha512-6QYvTxe8kLXa2u+npeFUJph0PVqaOK6BPyC2J4bM0iklS8wNyprwzpToxGUr0WZS6D8vRc8qbyxhN1JTUbu9kw==
   dependencies:
     "@alloc/quick-lru" "^5.2.0"
     "@types/pkginfo" "^0.4.0"


### PR DESCRIPTION
Updates `matrix-appservice-bridge` to `8.1.1` for auth token fixes.
https://github.com/matrix-org/matrix-appservice-bridge/releases/tag/8.1.1