### PR TITLE
Add error messages in setup widget

### DIFF
--- a/changelog.d/744.feature
+++ b/changelog.d/744.feature
@@ -1,0 +1,1 @@
+Add improved error messages in setup widget.

--- a/src/provisioning/Provisioner.ts
+++ b/src/provisioning/Provisioner.ts
@@ -182,7 +182,7 @@ export class Provisioner extends ProvisioningApi {
             return joinRulesEvent.join_rule === 'public';
         } catch (e) {
             throw new ApiError(
-                "Could not check if Matrix room is public",
+                "Could not check if room is public",
                 ErrCode.Unknown,
             );
         }

--- a/widget/src/SlackProvisioningClient.ts
+++ b/widget/src/SlackProvisioningClient.ts
@@ -41,22 +41,15 @@ export class SlackProvisioningClient {
         readonly client: ProvisioningClient,
     ) {}
 
-    getLink = async(roomId: string): Promise<GetLinkResponse | undefined> => {
-        try {
-            const res = await this.client.request(
-                'POST',
-                '/getlink',
-                {
-                    matrix_room_id: roomId,
-                },
-            );
-            return res as GetLinkResponse;
-        } catch (e) {
-            if (e instanceof ProvisioningError && e.errcode === 'SLACK_UNKNOWN_LINK') {
-                return undefined;
-            }
-            throw e;
-        }
+    getLink = async(roomId: string): Promise<GetLinkResponse> => {
+        const res = await this.client.request(
+            'POST',
+            '/getlink',
+            {
+                matrix_room_id: roomId,
+            },
+        );
+        return res as GetLinkResponse;
     };
 
     listWorkspaces = async(): Promise<SlackWorkspace[]> => {


### PR DESCRIPTION
Adds error messages in the setup widget to let the user know if they are not able to link the room. These will appear immediately when the widget loads:

1. When the Matrix room is not public, but `require_public_room` is `true`.

![Screenshot 2023-04-06 at 2 54 40 PM](https://user-images.githubusercontent.com/20007954/230476837-61b044c1-8dfe-43e3-bd03-4dbee0874b57.png)

2. When the user doesn't have sufficient permissions in the Matrix room.

![Screenshot 2023-04-06 at 2 55 38 PM](https://user-images.githubusercontent.com/20007954/230476855-9f2014bc-9971-4b1a-a4bf-56c8a5c31367.png)

Previously, you wouldn't see any error until actually trying to link a channel (and the messages were not very clear)

Fixes #743
