### PR TITLE
Add support for proxy to connect to the Slack API

### DIFF
--- a/changelog.d/750.feature
+++ b/changelog.d/750.feature
@@ -1,0 +1,1 @@
+Add support for proxy to connect to the Slack API.

--- a/config/config.sample-complete.yaml
+++ b/config/config.sample-complete.yaml
@@ -27,6 +27,8 @@ rtm:
 
 slack_hook_port: 9898
 
+slack_proxy: "https://proxy.server.here:3128"
+
 inbound_uri_prefix: "https://my.server.here:9898/"
 
 oauth2:

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -75,6 +75,10 @@ rtm:
 #
 slack_hook_port: 9898
 
+# Optional. Proxy to connect to the Slack API.
+#
+#slack_proxy: "https://proxy.server.here:3128"
+
 # Prefix of incoming requests to strip. This is NOT the bind host.
 # Unlike most of the other urls, this one cannot use localhost,
 # as this one must be publicly visible to the Slack API.

--- a/config/slack-config-schema.yaml
+++ b/config/slack-config-schema.yaml
@@ -54,6 +54,8 @@ properties:
         type: string
   slack_hook_port:
     type: integer
+  slack_proxy:
+    type: string
   inbound_uri_prefix:
     type: string
   oauth2:

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "axios": "^0.27.2",
     "classnames": "^2.3.2",
     "escape-string-regexp": "^4.0.0",
+    "https-proxy-agent": "^5.0.1",
     "matrix-appservice-bridge": "^8.1.1",
     "matrix-widget-api": "^1.1.1",
     "minimist": "^1.2.6",

--- a/src/IConfig.ts
+++ b/src/IConfig.ts
@@ -90,6 +90,7 @@ export interface IConfig {
 
     slack_hook_port?: number;
     slack_client_opts?: WebClientOptions;
+    slack_proxy?: string;
     enable_metrics: boolean;
 
     db?: {

--- a/src/SlackClientFactory.ts
+++ b/src/SlackClientFactory.ts
@@ -2,6 +2,7 @@ import { Datastore, TeamEntry } from "./datastore/Models";
 import { WebClient, WebClientOptions, LogLevel, Logger as SlackLogger, WebAPIPlatformError } from "@slack/web-api";
 import { Logger } from "matrix-appservice-bridge";
 import { TeamInfoResponse, AuthTestResponse, UsersInfoResponse } from "./SlackResponses";
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 const webLog = new Logger("slack-api");
 const log = new Logger("SlackClientFactory");
@@ -18,6 +19,7 @@ const AUTH_INTERVAL_MS = 5 * 60000;
 
 interface RequiredConfigOptions {
     slack_client_opts?: WebClientOptions;
+    slack_proxy?: string;
     auth_interval_ms?: number;
 }
 
@@ -39,7 +41,12 @@ export class SlackClientFactory {
     }
 
     public async createClient(token: string): Promise<WebClient> {
-        const opts = this.config.slack_client_opts ? this.config.slack_client_opts : undefined;
+        const opts = this.config.slack_client_opts ? this.config.slack_client_opts : {};
+
+        if (this.config.slack_proxy) {
+            opts.agent = new HttpsProxyAgent(this.config.slack_proxy);
+        }
+
         return new WebClient(token, {
             logger: {
                 getLevel: () => LogLevel.DEBUG,


### PR DESCRIPTION
Hello, thank you for this project!

I am using this bridge in an environment that requires me to use a proxy to connect to the Slack API, therefore I needed to add the feature.

Credit to https://github.com/matrix-org/matrix-appservice-slack/pull/338 for starting the work.

Signed off by: Gaël Berthaud-Müller <gael+github@berthaud-muller.eu>

