### PR TITLE
Create a new ping room if the previous room cannot be reached

### DIFF
--- a/changelog.d/752.bugfix
+++ b/changelog.d/752.bugfix
@@ -1,0 +1,1 @@
+Fix a case where the bridge will fail to start if it cannot access it's internal ping room

--- a/changelog.d/752.bugfix
+++ b/changelog.d/752.bugfix
@@ -1,1 +1,1 @@
-Fix a case where the bridge will fail to start if it cannot access it's internal ping room
+Fix a case where the bridge will fail to start if it cannot access it's internal ping room.

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1707,12 +1707,23 @@ export class Main {
 
     private async pingBridge() {
         let internalRoom: string|null;
+        const intent = this.bridge.getIntent();
         try {
             internalRoom = await this.datastore.getUserAdminRoom("-internal-");
+            if (internalRoom) {
+                try {
+                    await intent.join(internalRoom);
+                } catch (ex) {
+                    // Unable to join the room, probably broken. Create another.
+                    internalRoom = null;
+                }
+            }
+
             if (!internalRoom) {
-                internalRoom = (await this.bridge.getIntent().createRoom({ options: {}})).room_id;
+                internalRoom = (await intent.createRoom({ options: {}})).room_id;
                 await this.datastore.setUserAdminRoom("-internal-", internalRoom);
             }
+
             const time = await this.bridge.pingAppserviceRoute(internalRoom);
             log.info(`Successfully pinged the bridge. Round trip took ${time}ms`);
         }


### PR DESCRIPTION
If the room the bridge is using to "ping" the homeserver has been deleted, we will fail to start because the pings will always immediately fail. Instead, try to join the room and if we fail, create another. Joins will noop if we're already in the room.