### PR TITLE
docs: stabilize the mkdocs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs==1.2.3
+mkdocs==1.2.4
 mkdocs-bootswatch==1.1
 pygments


### PR DESCRIPTION
I found that [a build on Read The Docs](https://readthedocs.org/projects/matrix-appservice-slack/builds/20359556/) failed due to [the known issue caused by breaking API change in jinja2](https://github.com/mkdocs/mkdocs/issues/2794#issuecomment-1079764404).

The [mkdocs 1.2.4 release](https://github.com/mkdocs/mkdocs/releases/tag/1.2.4) contains necessary fix, so upgrading mkdocs in the `docs/requirements.txt` will stabilize the build on Read The Docs.

