### PR TITLE
Display channel name in list command

### DIFF
--- a/changelog.d/756.bugfix
+++ b/changelog.d/756.bugfix
@@ -1,0 +1,1 @@
+Fix issue that caused channel name to not be displayed in the list command output.

--- a/src/AdminCommands.ts
+++ b/src/AdminCommands.ts
@@ -102,7 +102,7 @@ export class AdminCommands {
                     }
 
                     const slack = r.SlackChannelId ?
-                        `${channelName} (${r.SlackChannelId})` :
+                        `#${channelName} (${r.SlackChannelId})` :
                         channelName;
 
                     let status = r.getStatus();

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1405,7 +1405,7 @@ export class Main {
         }
 
         let channelInfo: ConversationsInfoResponse|undefined;
-        if (slackClient && opts.slack_channel_id && opts.team_id) {
+        if (slackClient && opts.slack_channel_id) {
             // PSA: Bots cannot join channels, they have a limited set of APIs https://api.slack.com/methods/bots.info
 
             channelInfo = (await slackClient.conversations.info({ channel: opts.slack_channel_id})) as ConversationsInfoResponse;

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -23,10 +23,12 @@ const log = new Logger("SlackEventHandler");
 /**
  * https://api.slack.com/events/channel_rename
  */
-interface ISlackEventChannelRename extends ISlackEvent {
-    id: string;
-    name: string;
-    created: number;
+interface ISlackEventChannelRename extends Omit<ISlackEvent, "channel"> {
+    channel: {
+        id: string;
+        name: string;
+        created: number;
+    }
 }
 
 /**
@@ -190,7 +192,10 @@ export class SlackEventHandler extends BaseSlackHandler {
                 await this.handleReaction(event as ISlackEventReaction, teamId);
                 break;
             case "channel_rename":
-                await this.handleChannelRenameEvent(event as ISlackEventChannelRename);
+                // The rename event is not compatible with ISlackEvent because the channel property is an object,
+                // not a string. So we resort to casting to unknown first.
+                // TODO: Move channel property out of ISlackEvent, into each event type, where relevant.
+                await this.handleChannelRenameEvent((event as unknown) as ISlackEventChannelRename);
                 break;
             case "team_domain_change":
                 await this.handleDomainChangeEvent(event as ISlackEventTeamDomainChange, teamId);
@@ -349,12 +354,10 @@ export class SlackEventHandler extends BaseSlackHandler {
     }
 
     private async handleChannelRenameEvent(event: ISlackEventChannelRename) {
-        // TODO test me. and do we even need this? doesn't appear to be used anymore
-        const room = this.main.rooms.getBySlackChannelId(event.id);
+        const room = this.main.rooms.getBySlackChannelId(event.channel.id);
         if (!room) { throw new Error("unknown_channel"); }
 
-        const channelName = `#${event.name}`;
-        room.SlackChannelName = channelName;
+        room.SlackChannelName = `#${event.channel.name}`;
         if (room.isDirty) {
             await this.main.datastore.upsertRoom(room);
         }

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -357,7 +357,7 @@ export class SlackEventHandler extends BaseSlackHandler {
         const room = this.main.rooms.getBySlackChannelId(event.channel.id);
         if (!room) { throw new Error("unknown_channel"); }
 
-        room.SlackChannelName = `#${event.channel.name}`;
+        room.SlackChannelName = event.channel.name;
         if (room.isDirty) {
             await this.main.datastore.upsertRoom(room);
         }


### PR DESCRIPTION
Fixes #349 
Signed-off-by: Paulo Pinto <paulo.pinto@automattic.com>

This PR fixes issues related to saving the slack channel name in the database:

1. Channel name was not being set by the `link` command
2. Channel name was not being updated when the channel is renamed

This resulted in the channel name being displayed as `UNKNOWN` when issuing a `link` command.

#### Before
<img width="668" alt="Screenshot 2023-07-03 at 16 25 59" src="https://github.com/matrix-org/matrix-appservice-slack/assets/550401/a7a2447d-601c-4635-b701-d19c5ada1f34">

#### After
<img width="627" alt="Screenshot 2023-07-03 at 16 19 25" src="https://github.com/matrix-org/matrix-appservice-slack/assets/550401/ffb54611-0e07-42b2-bef4-4ae144c23820">