### PR TITLE
Fix swallowed text between 2 mentions

### DIFF
--- a/changelog.d/772.bugfix
+++ b/changelog.d/772.bugfix
@@ -1,1 +1,1 @@
-Fix swallowed text between 2 mentions
+Fix swallowed text between 2 mentions.

--- a/changelog.d/772.bugfix
+++ b/changelog.d/772.bugfix
@@ -1,0 +1,1 @@
+Fix swallowed text between 2 mentions

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -314,7 +314,7 @@ export class SlackGhost {
     public prepareBody(body: string): string {
         // TODO: This is fixing plaintext mentions, but should be refactored.
         // See https://github.com/matrix-org/matrix-appservice-slack/issues/110
-        return body.replace(/<https:\/\/matrix\.to\/#\/@.+:.+\|(.+)>/g, "$1");
+        return body.replace(/<https:\/\/matrix\.to\/#\/@[^:]+:[^|]+\|([^>]+)>/g, "$1");
     }
 
     public prepareFormattedBody(body: string): string {


### PR DESCRIPTION
When there are two mentions in a single Slack message, the text between the messages is swallowed.

I've extracted some code to make it easier to see the fix:

```js
const USER_ID_REGEX = /<@(\w+)\|?\w*?>/g;
let text = 'Hello <@U123> ! :wave: I\'m pinging <@U456> as he would be the best folk to answer your question :slightly_smiling_face:';

let match = null;
while ((match = USER_ID_REGEX.exec(text)) !== null) {
    // foreach userId, pull out the ID
    // (if this is an emote msg, the format is <@ID|nick>, but in normal msgs it's just <@ID>
    const id = match[1];
    let displayName = "";
    let userId = '';
    if ( id === 'U123') userId = '@randy:server';
    if ( id === 'U456') userId = '@akirk:server';

    const users = {};
    if ( id === 'U123') users.displayName = 'Randy';
    if ( id === 'U456') users.displayName = 'Alex Kirk';

    if (!userId) {
        log.warn("Mentioned user not in store. Looking up display name from slack.");
        // if the user is not in the store then we look up the displayname
        displayName = users.displayName;
        // If the user is not in the room, we can't pills them, we have to just plain text mention them.
        text = text.slice(0, match.index) + displayName + text.slice(match.index + match[0].length);
    } else {
        displayName = users.displayName || userId;
        text = text.slice(0, match.index) + `<https://matrix.to/#/${userId}|${displayName}>` + text.slice(match.index + match[0].length);
    }
}

// TODO: This is fixing plaintext mentions, but should be refactored.
// https://github.com/matrix-org/matrix-appservice-slack/issues/110
console.log( text.replace(/<https:\/\/matrix\.to\/#\/@.+:.+\|(.+)>/g, "$1") );
console.log( text.replace(/<https:\/\/matrix\.to\/#\/@[^:]+:[^|]+\|([^>]+)>/g, "$1") );
```

outputs
```
Hello Alex Kirk as he would be the best folk to answer your question :slightly_smiling_face:
Hello Randy ! :wave: I'm pinging Alex Kirk as he would be the best folk to answer your question :slightly_smiling_face:
```
The first line is using the current regex which swallows text, the second one is the improved one.

Signed-off-by: Alex Kirk <akirk@users.noreply.github.com>