### PR TITLE
User correct Matrix accounts when redacting events

### DIFF
--- a/changelog.d/766.bugfix
+++ b/changelog.d/766.bugfix
@@ -1,0 +1,1 @@
+User correct Matrix accounts when redacting events.

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -50,6 +50,7 @@ export interface ISlackEventMessageAttachment {
 }
 
 export interface ISlackMessageEvent extends ISlackEvent {
+    team?: string;
     team_domain?: string;
     team_id?: string;
     user?: string;

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -296,7 +296,7 @@ export class SlackEventHandler extends BaseSlackHandler {
                     log.error("Cannot delete message with no previous_message:", msg);
                     return;
                 }
-                if (previousMessage.subtype === 'bot_message') {
+                if (previousMessage.subtype === 'bot_message' && (previousMessage.bot_id === team.bot_id)) {
                     // Sent from Matrix, try to remove it with our bot account
                     try {
                         const botClient = this.main.botIntent.matrixClient;

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -321,6 +321,13 @@ export class SlackGhost {
         return Slackdown.parse(body);
     }
 
+    public async redactEvent(roomId: string, eventId: string) {
+        if (!this._intent) {
+            throw Error('No intent associated with ghost');
+        }
+        await this._intent.matrixClient.redactEvent(roomId, eventId);
+    }
+
     public async sendInThread(roomId: string, text: string, slackRoomId: string,
         slackEventTs: string, replyEvent: IMatrixReplyEvent): Promise<void> {
         const content = {


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-appservice-slack/issues/766

For events sent from Slack and later deleted from Slack, we use the same Slack Ghost that sent the message – this alleviates the need for an elevated Power Level.

For events sent from Matrix and deleted from Slack, we try to use our bot account. This does require us to have a sufficient power level, so we try to be helpful in the logs if we don't.

Note: Slack doesn't tell us who deleted the message, so we can't bridge that precisely – the sender of a redact event is just our best effort.