### PR TITLE
Support editing/removing multipart Slack messages

### DIFF
--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -50,6 +50,7 @@ export interface ISlackEventMessageAttachment {
 }
 
 export interface ISlackMessageEvent extends ISlackEvent {
+    team?: string;
     team_domain?: string;
     team_id?: string;
     user?: string;

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -878,7 +878,7 @@ export class BridgedRoom {
                 formatted_body: `<a href="${link}">${file.name}</a>`,
                 msgtype: "m.text",
             };
-            await ghost.sendMessage(this.matrixRoomId, messageContent, channelId, slackEventId);
+            await ghost.sendMessage(this.matrixRoomId, messageContent, channelId, slackEventId, { type: "attachment" });
             return;
         }
 
@@ -917,7 +917,7 @@ export class BridgedRoom {
                 formatted_body: htmlCode,
                 msgtype: "m.text",
             };
-            await ghost.sendMessage(this.matrixRoomId, messageContent, channelId, slackEventId);
+            await ghost.sendMessage(this.matrixRoomId, messageContent, channelId, slackEventId, { type: "attachment" });
             return;
         }
 
@@ -954,6 +954,7 @@ export class BridgedRoom {
             slackFileToMatrixMessage(file, fileContentUri, thumbnailContentUri),
             channelId,
             slackEventId,
+            { type: "attachment" },
         );
     }
 

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -699,8 +699,9 @@ export class BridgedRoom {
                 await new Promise((r) => setTimeout(r, PUPPET_INCOMING_DELAY_MS));
             }
         }
-        if (this.recentSlackMessages.includes(message.ts)) {
+        if (this.recentSlackMessages.includes(message.event_ts ?? message.ts)) {
             // We sent this, ignore.
+            log.debug('Ignoring message recently sent by us');
             return;
         }
         try {
@@ -712,8 +713,8 @@ export class BridgedRoom {
             }
             this.slackSendLock = this.slackSendLock.then(() => {
                 // Check again
-                if (this.recentSlackMessages.includes(message.ts)) {
-                    // We sent this, ignore
+                if (this.recentSlackMessages.includes(message.event_ts ?? message.ts)) {
+                    log.debug('Ignoring message recently sent by us');
                     return;
                 }
                 return this.handleSlackMessage(message, ghost).catch((ex) => {

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -284,6 +284,7 @@ export class SlackEventHandler extends BaseSlackHandler {
             if (msg.message.bot_id !== undefined) {
                 // Check the edit wasn't sent by us
                 if (msg.message.bot_id === team.bot_id) {
+                    log.debug('Ignoring a message_changed since it was sent by us');
                     return;
                 } else {
                     msg.user_id = msg.message.bot_id;

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -296,7 +296,7 @@ export class SlackEventHandler extends BaseSlackHandler {
                     log.error("Cannot delete message with no previous_message:", msg);
                     return;
                 }
-                if (previousMessage.subtype === 'bot_message') {
+                if (previousMessage.subtype === 'bot_message' && (previousMessage.bot_id === team.bot_id)) {
                     // Sent from Matrix, try to remove it with our bot account
                     try {
                         const botClient = this.main.botIntent.matrixClient;

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -19,7 +19,7 @@ import * as Slackdown from "Slackdown";
 import { ISlackUser } from "./BaseSlackHandler";
 import { WebClient } from "@slack/web-api";
 import { BotsInfoResponse, UsersInfoResponse } from "./SlackResponses";
-import { UserEntry, Datastore } from "./datastore/Models";
+import { UserEntry, Datastore, EventEntryExtra } from "./datastore/Models";
 import axios from "axios";
 
 const log = new Logger("SlackGhost");
@@ -368,7 +368,13 @@ export class SlackGhost {
         await this.sendMessage(roomId, content, slackRoomID, slackEventTS);
     }
 
-    public async sendMessage(roomId: string, msg: Record<string, unknown>, slackRoomId: string, slackEventTs: string): Promise<{event_id: string}> {
+    public async sendMessage(
+        roomId: string,
+        msg: Record<string, unknown>,
+        slackRoomId: string,
+        slackEventTs: string,
+        eventExtras?: EventEntryExtra,
+    ): Promise<{event_id: string}> {
         if (!this._intent) {
             throw Error('No intent associated with ghost');
         }
@@ -383,6 +389,7 @@ export class SlackGhost {
             matrixEvent.event_id,
             slackRoomId,
             slackEventTs,
+            eventExtras,
         );
 
         return {

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -321,6 +321,13 @@ export class SlackGhost {
         return Slackdown.parse(body);
     }
 
+    public async redactEvent(roomId: string, eventId: string) {
+        if (!this._intent) {
+            throw Error('No intent associated with ghost');
+        }
+        await this._intent.matrixClient.redactEvent(roomId, eventId);
+    }
+
     public async sendInThread(roomId: string, text: string, slackRoomId: string,
         slackEventTs: string, replyEvent: IMatrixReplyEvent): Promise<void> {
         const content = {

--- a/src/datastore/Models.ts
+++ b/src/datastore/Models.ts
@@ -50,6 +50,7 @@ export interface EventEntry {
 }
 
 export interface EventEntryExtra {
+    type?: 'attachment';
     slackThreadMessages?: string[];
 }
 

--- a/src/datastore/Models.ts
+++ b/src/datastore/Models.ts
@@ -50,7 +50,7 @@ export interface EventEntry {
 }
 
 export interface EventEntryExtra {
-    type?: 'attachment';
+    attachment_id?: string;
     slackThreadMessages?: string[];
 }
 
@@ -114,6 +114,7 @@ export interface Datastore extends ProvisioningStore {
     upsertEvent(roomId: string, eventId: string, channelId: string, ts: string, extras?: EventEntryExtra): Promise<null>;
     upsertEvent(roomIdOrEntry: EventEntry): Promise<null>;
     getEventByMatrixId(roomId: string, eventId: string): Promise<EventEntry|null>;
+    getEventsBySlackId(channelId: string, ts: string): Promise<EventEntry[]>;
     getEventBySlackId(channelId: string, ts: string): Promise<EventEntry|null>;
     deleteEventByMatrixId(roomId: string, eventId: string): Promise<null>;
 

--- a/src/datastore/NedbDatastore.ts
+++ b/src/datastore/NedbDatastore.ts
@@ -241,6 +241,10 @@ export class NedbDatastore implements Datastore {
         return this.storedEventToEventEntry(storedEvent);
     }
 
+    public async getEventsBySlackId(channelId: string, ts: string): Promise<EventEntry[]> {
+        return this.getEventBySlackId(channelId, ts).then(e => e ? [e] : []);
+    }
+
     public async getEventBySlackId(channelId: string, ts: string): Promise<EventEntry|null> {
         const storedEvent = await this.eventStore.getEntryByRemoteId(channelId, ts);
         if (!storedEvent) {

--- a/src/datastore/postgres/schema/v17.ts
+++ b/src/datastore/postgres/schema/v17.ts
@@ -1,0 +1,11 @@
+import { IDatabase } from "pg-promise";
+
+export const runSchema = async(db: IDatabase<unknown>) => {
+    await db.none(`
+        ALTER TABLE events DROP CONSTRAINT cons_events_unique;
+    `);
+
+    await db.none(`
+        ALTER TABLE events ADD CONSTRAINT cons_events_unique UNIQUE(eventid, roomid, slackchannel, slackts, extras);
+    `);
+};


### PR DESCRIPTION
We may produce multiple Matrix events per Slack events, if the Slack events contains text with attachments. This should have been forbidden with a DB constraint, but for some reason it happened regardless.

This updates the constraint to match reality, differentiating Matrix events by the type of incoming Slack event. For backwards compatibility reasons getEventBySlackId() returns the "main" Matrix event.

When handling message changes and message deletion, we will now correctly edit the right part of the message – either changing the text or removing some of the attachments (fixes https://github.com/matrix-org/matrix-appservice-slack/issues/486). Deleting the whole message will now also remove all the attachments associated with it.

Depends on https://github.com/matrix-org/matrix-appservice-slack/pull/780

Does not support NeDB, but I wonder if we want to support NeDB at all these days (ref https://github.com/matrix-org/matrix-appservice-slack/pull/775)
