### PR TITLE
suggested bot name is wrong

### DIFF
--- a/widget/src/SlackApp.tsx
+++ b/widget/src/SlackApp.tsx
@@ -346,7 +346,7 @@ const Linked = ({
                 This room is linked to <span className="font-semibold">{channelName}</span>.
             </Text.Body>
             <Text.Caption className="text-grey-200">
-                Make sure you invite the bot to this Slack channel: <span className="font-semibold">/invite @element_bridge</span>
+                Make sure you invite the bot to this Slack channel: <span className="font-semibold">/invite @riot_bridge</span>
             </Text.Caption>
             <div className="flex justify-end">
                 <Buttons.Outline color="danger" onClick={unlinkChannel}>


### PR DESCRIPTION
It seems that the name of the bot is now `@riot_bridge`, at least for the slack-bridge configured by default `by Element`.