### PR TITLE
Fix broken link

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -31,7 +31,7 @@ These types are supported in both directions.
 - Redactions
 - Edits [3]
 - Threading / Replies [2]
-- [Encrypted Messages](./bridge-encryption) 🧪
+- [Encrypted Messages](/bridge-encryption) 🧪
 
 ## Membership
 


### PR DESCRIPTION
The link was /en/latest/features/bridge-encryption, `mkdocs` was building wrongly the route because of the dot. You need an absolute route (start with /) instead of a relative one (starting with .)