### PR TITLE
Fix newsfile workflow

### DIFF
--- a/.github/workflows/newsfile.yml
+++ b/.github/workflows/newsfile.yml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/checkout@v2
         with: # Needed for comparison
           fetch-depth: 0
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.9'
-      - run: pip install towncrier==21.9.0
+      - uses: actions/setup-python@v2
+      - run: pip install towncrier==22.8.0
       - name: ":newspaper: Newsfile"
         run: ./scripts/check-newsfragment
+        env:
+          PULL_REQUEST_NUMBER: ${{ github.event.number }}

--- a/changelog.d/800.misc
+++ b/changelog.d/800.misc
@@ -1,0 +1,1 @@
+Fix the GitHub workflow for verifying news files on PR branches.


### PR DESCRIPTION
This updates the versions of the setup-python action & towncrier to match what's used by matrix-appservice-bridge, and to set the PR number in the checker script as m-a-b does.

This was done to fix the workflow failing on recent runs.